### PR TITLE
Add --deps build option to select the prebuilt dependency source

### DIFF
--- a/.github/workflows/generate_deploy_documentation.yml
+++ b/.github/workflows/generate_deploy_documentation.yml
@@ -68,7 +68,7 @@ jobs:
           set -e
           sudo chown -R $USER:$USER /home/runner/work/radarsimpy
           chmod +x build.sh
-          ./build.sh --license=off --arch=cpu --test=off
+          ./build.sh --license=off --arch=cpu --test=off --deps=release
         shell: bash
 
       - name: Generate Sphinx documentation

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           echo "::group::Build Process"
           chmod +x build.sh
-          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose
+          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose --deps=release
           echo "::endgroup::"
 
       - name: Display build statistics

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -164,7 +164,7 @@ jobs:
           echo "::group::Build Process"
           sudo chown -R $USER:$USER /home/runner/work/radarsimpy
           chmod +x build.sh
-          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose
+          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose --deps=release
           echo "::endgroup::"
 
       - name: Display build statistics

--- a/.github/workflows/release_ubuntu_cuda12.yml
+++ b/.github/workflows/release_ubuntu_cuda12.yml
@@ -175,7 +175,7 @@ jobs:
           echo "::group::Build Process"
           sudo chown -R $USER:$USER /home/runner/work/radarsimpy
           chmod +x build.sh
-          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose
+          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose --deps=release
           echo "::endgroup::"
 
       - name: Display build statistics

--- a/.github/workflows/release_ubuntu_cuda13.yml
+++ b/.github/workflows/release_ubuntu_cuda13.yml
@@ -188,7 +188,7 @@ jobs:
           echo "::group::Build Process"
           sudo chown -R $USER:$USER /home/runner/work/radarsimpy
           chmod +x build.sh
-          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose
+          ./build.sh --license=on --arch=${{ matrix.arch }} --test=off --verbose --deps=release
           echo "::endgroup::"
 
       - name: Display build statistics

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Build RadarSimPy
         run: |
           echo "::group::Build Process"
-          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off
+          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off --deps=release
           echo "::endgroup::"
         shell: cmd
 

--- a/.github/workflows/release_windows_cuda12.yml
+++ b/.github/workflows/release_windows_cuda12.yml
@@ -152,7 +152,7 @@ jobs:
           CUDA_TOOLKIT_ROOT_DIR: ${{ env.CUDA_PATH }}
         run: |
           echo "::group::Build Process"
-          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off
+          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off --deps=release
           echo "::endgroup::"
         shell: cmd
 

--- a/.github/workflows/release_windows_cuda13.yml
+++ b/.github/workflows/release_windows_cuda13.yml
@@ -155,7 +155,7 @@ jobs:
           CUDA_TOOLKIT_ROOT_DIR: ${{ env.CUDA_PATH }}
         run: |
           echo "::group::Build Process"
-          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off
+          .\build.bat --license=on --arch=${{ matrix.arch }} --test=off --deps=release
           echo "::endgroup::"
         shell: cmd
 

--- a/.github/workflows/unit_test_macos.yml
+++ b/.github/workflows/unit_test_macos.yml
@@ -140,7 +140,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           chmod +x build.sh
-          ./build.sh --license=on --arch=cpu --test=on
+          ./build.sh --license=on --arch=cpu --test=on --deps=release
 
       - name: Display build logs on failure
         if: failure()

--- a/.github/workflows/unit_test_ubuntu.yml
+++ b/.github/workflows/unit_test_ubuntu.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER /home/runner/work/radarsimpy
           chmod +x build.sh
-          ./build.sh --license=on --arch=${{ matrix.arch }} --test=on
+          ./build.sh --license=on --arch=${{ matrix.arch }} --test=on --deps=release
 
       - name: Display build logs on failure
         if: failure()

--- a/.github/workflows/unit_test_windows.yml
+++ b/.github/workflows/unit_test_windows.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          .\build.bat --license=on --arch=${{ matrix.arch }} --test=on
+          .\build.bat --license=on --arch=${{ matrix.arch }} --test=on --deps=release
         env:
           PYTHONPATH: ${{ github.workspace }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - `Receiver.gate_delay` and `Receiver.gate_range` properties
 - `Radar.chirp_slope`, `Radar.unambiguous_range_span` and `Radar.unambiguous_range_window` properties, describing deramp (stretch) processing of a linear FM waveform. The window is one-sided `[0, span]` when un-gated (all beat tones are positive, so the full `[0, fs)` band is usable) and two-sided `gate_range +/- span/2` when gated (the residual delay is signed). All three report `None` when the waveform is not a linear FM ramp
 - Range gate test suite (`test_system_range_gate.py`)
+- `--deps` build option (`build.sh` / `build.bat`) selecting where the prebuilt third-party libraries come from: `repo` (default) reads the committed `libs/` tree in the `radarsimx-deps` submodule and needs no network, `release` downloads the checksum-pinned `radarsimx-deps` GitHub release archives into a cache outside the build directory. All GitHub Actions workflows now build with `--deps=release`
 - Runtime CPU fallback for machines without a GPU. The execution policies resolve at compile time, so a GPU-enabled build would attempt CUDA execution even where no device exists; `sim_radar`, `sim_rcs` and `sim_lidar` now probe for a usable CUDA device and dispatch to the CPU policy when there is none. `sim_radar(device="gpu")` reports the fallback as a `RuntimeWarning`. A CPU-only build is unaffected, and an explicit `device="cpu"` request is unchanged
 - CPU fallback test suite (`test_system_cpu_fallback.py`)
 

--- a/build.bat
+++ b/build.bat
@@ -28,12 +28,17 @@ REM   --license=[on/off]  Enable license verification: 'on' or 'off' (default: o
 REM   --arch=[cpu/gpu]    Build architecture: 'cpu' or 'gpu' (default: cpu)
 REM   --test=[on/off]     Enable unit tests: 'on' or 'off' (default: on)
 REM   --jobs=N            Number of parallel build jobs (default: auto-detect)
+REM   --deps=[repo/release] Source of the prebuilt third-party libraries:
+REM                       'repo' uses the committed libs\ tree in the
+REM                       radarsimx-deps submodule, 'release' downloads the
+REM                       radarsimx-deps GitHub release archives (default: repo)
 REM
 REM EXAMPLES:
 REM   build.bat                                    REM Default build
 REM   build.bat --license=on --arch=gpu          REM GPU build with license verification
 REM   build.bat --jobs=8 --test=off              REM 8-core parallel build, no tests
 REM   build.bat --arch=cpu --license=on          REM CPU build with license verification
+REM   build.bat --deps=release                   REM Download prebuilt deps from a release
 REM
 REM EXIT CODES:
 REM   0  - Success
@@ -49,6 +54,7 @@ REM Default build configuration
 set LICENSE=off
 set ARCH=cpu
 set TEST=on
+set DEPS=repo
 set BUILD_TYPE=Release
 set SCRIPT_DIR=%~dp0
 set BUILD_FAILED=0
@@ -79,12 +85,16 @@ REM Help section - displays command line parameter usage
     echo   --arch=ARCH         Build architecture: 'cpu' or 'gpu' (default: cpu)
     echo   --test=TEST         Enable unit tests: 'on' or 'off' (default: on)
     echo   --jobs=N            Number of parallel build jobs (default: auto-detect)
+    echo   --deps=DEPS         Prebuilt dependency source: 'repo' or 'release' (default: repo)
+    echo                         repo    - committed libs\ tree in the radarsimx-deps submodule
+    echo                         release - radarsimx-deps GitHub release archives (needs network)
     echo.
     echo EXAMPLES:
     echo   %~nx0                                    # Default build
     echo   %~nx0 --license=on --arch=gpu          # GPU build with license verification
     echo   %~nx0 --jobs=8 --test=off              # 8-core parallel build, no tests
     echo   %~nx0 --arch=cpu --license=on          # CPU build with license verification
+    echo   %~nx0 --deps=release                   # Download prebuilt deps from a release
     echo.
     echo WINDOWS-SPECIFIC NOTES:
     echo   - Uses MSVC compiler, creates .dll files
@@ -117,12 +127,14 @@ REM   LICENSE - License verification (on/off)
 REM   ARCH - Build architecture (cpu/gpu)
 REM   TEST - Unit test flag (on/off)
 REM   JOBS - Number of parallel build jobs
+REM   DEPS - Prebuilt dependency source (repo/release)
 REM Supported Options:
 REM   --help: Shows help and exits
 REM   --license=VALUE: Enables/disables license verification
 REM   --arch=VALUE: Sets architecture
 REM   --test=VALUE: Enables/disables tests
 REM   --jobs=VALUE: Sets parallel job count
+REM   --deps=VALUE: Selects the prebuilt dependency source
 REM Exit:
 REM   Exits with code 0 on --help
 REM   Exits with code 1 on unknown options or validation errors
@@ -154,6 +166,12 @@ REM   Exits with code 1 on unknown options or validation errors
         shift
         goto GETOPTS
     )
+    if /I "%1" == "--deps" (
+        set DEPS=%2
+        shift
+        shift
+        goto GETOPTS
+    )
     if not "%1" == "" (
         echo ERROR: Unknown parameter: %1
         echo Use --help for usage information
@@ -180,6 +198,14 @@ REM   Exits with code 1 on unknown options or validation errors
     if /I NOT "%TEST%" == "on" (
         if /I NOT "%TEST%" == "off" (
             echo ERROR: Invalid --test parameter '%TEST%'. Please choose 'on' or 'off'
+            goto ERROR_EXIT
+        )
+    )
+
+    REM Validate prebuilt dependency source parameter
+    if /I NOT "%DEPS%" == "repo" (
+        if /I NOT "%DEPS%" == "release" (
+            echo ERROR: Invalid --deps parameter '%DEPS%'. Please choose 'repo' or 'release'
             goto ERROR_EXIT
         )
     )
@@ -323,6 +349,7 @@ REM Display banner and copyright information
     echo   - Tests: %TEST%
     echo   - Build Type: %BUILD_TYPE%
     echo   - Parallel Jobs: %JOBS%
+    echo   - Prebuilt Dependencies: %DEPS%
     echo   - Script Directory: %SCRIPT_DIR%
     echo.
     echo ######                               #####           #     # 
@@ -399,6 +426,7 @@ REM Global Variables Used:
 REM   ARCH - Determines GPU_BUILD CMake option
 REM   LICENSE - Determines ENABLE_LICENSE CMake option
 REM   TEST - Determines GTEST CMake option
+REM   DEPS - Determines RADARSIMCPP_DEPS_PREFER_DOWNLOAD CMake option
 REM   BUILD_TYPE - CMake build configuration (Release/Debug)
 REM   JOBS - Number of parallel build jobs
 REM Output:
@@ -421,27 +449,28 @@ REM   Sets CMAKE_FAILED=1 and exits on any CMake failures
     REM Change to build directory
     pushd ".\src\radarsimcpp\build"
     
-    REM Configure CMake build based on architecture, license, and test settings
-    echo INFO: Configuring CMake build - Architecture: %ARCH%, License: %LICENSE%, Tests: %TEST%...
-    
+    REM Configure CMake build based on architecture, license, test and dependency settings
+    echo INFO: Configuring CMake build - Architecture: %ARCH%, License: %LICENSE%, Tests: %TEST%, Deps: %DEPS%...
+
     REM Set license flag
     set LICENSE_FLAG=OFF
     if /I "%LICENSE%" == "on" set LICENSE_FLAG=ON
-    
-    if /I "%ARCH%" == "gpu" (
-        if /I "%TEST%" == "on" (
-            cmake -DGPU_BUILD=ON -DENABLE_LICENSE=%LICENSE_FLAG% -DGTEST=ON ..
-        ) else (
-            cmake -DGPU_BUILD=ON -DENABLE_LICENSE=%LICENSE_FLAG% -DGTEST=OFF ..
-        )
-    ) else (
-        if /I "%TEST%" == "on" (
-            cmake -DENABLE_LICENSE=%LICENSE_FLAG% -DGTEST=ON ..
-        ) else (
-            cmake -DENABLE_LICENSE=%LICENSE_FLAG% -DGTEST=OFF ..
-        )
-    )
-    
+
+    REM Set test flag
+    set GTEST_FLAG=OFF
+    if /I "%TEST%" == "on" set GTEST_FLAG=ON
+
+    REM Select where the prebuilt third-party libraries come from. 'repo' uses the
+    REM committed libs\ tree in the radarsimx-deps submodule and needs no network;
+    REM 'release' downloads the checksum-pinned archives from the deps release.
+    set DEPS_DOWNLOAD_FLAG=OFF
+    if /I "%DEPS%" == "release" set DEPS_DOWNLOAD_FLAG=ON
+
+    set CMAKE_OPTIONS=-DENABLE_LICENSE=!LICENSE_FLAG! -DGTEST=!GTEST_FLAG! -DRADARSIMCPP_DEPS_PREFER_DOWNLOAD=!DEPS_DOWNLOAD_FLAG!
+    if /I "%ARCH%" == "gpu" set CMAKE_OPTIONS=-DGPU_BUILD=ON !CMAKE_OPTIONS!
+
+    cmake !CMAKE_OPTIONS! ..
+
     if %errorlevel% neq 0 (
         echo ERROR: CMake configuration failed
         set CMAKE_FAILED=1
@@ -644,6 +673,7 @@ REM Build completion
     echo   - Tests: %TEST%
     echo   - Build Type: %BUILD_TYPE%
     echo   - Parallel Jobs: %JOBS%
+    echo   - Prebuilt Dependencies: %DEPS%
     echo   - Script Directory: %SCRIPT_DIR%
     echo.
     echo Output Locations:
@@ -677,6 +707,7 @@ REM Error handling
     echo   - Tests: %TEST%
     echo   - Build Type: %BUILD_TYPE%
     echo   - Parallel Jobs: %JOBS%
+    echo   - Prebuilt Dependencies: %DEPS%
     echo.
     echo Error Summary:
     if %CMAKE_FAILED% neq 0 echo   - CMake configuration or build failed

--- a/build.sh
+++ b/build.sh
@@ -36,12 +36,17 @@
 #   --jobs=N            Number of parallel build jobs (default: auto-detect)
 #   --clean=CLEAN       Clean build artifacts: 'true' or 'false' (default: true)
 #   --verbose           Enable verbose output (default: true)
+#   --deps=<repo|release> Source of the prebuilt third-party libraries:
+#                       'repo' uses the committed libs/ tree in the
+#                       radarsimx-deps submodule, 'release' downloads the
+#                       radarsimx-deps GitHub release archives (default: repo)
 #   --cmake-args=ARGS   Additional CMake arguments
 #
 # EXAMPLES:
 #   ./build.sh                                    # Default build
 #   ./build.sh --license=on --arch=gpu          # GPU build with license verification
 #   ./build.sh --jobs=8 --verbose               # 8-core parallel build
+#   ./build.sh --deps=release                   # Download prebuilt deps from a release
 #   ./build.sh --cmake-args="-DCUSTOM_FLAG=ON"  # Custom CMake flags
 #
 # EXIT CODES:
@@ -154,12 +159,16 @@ OPTIONS:
     --jobs=N            Number of parallel build jobs (default: auto-detect)
     --clean             Clean build artifacts before building (default: true)
     --verbose           Enable verbose output (default: false)
+    --deps=DEPS         Prebuilt dependency source: 'repo' or 'release' (default: repo)
+                          repo    - committed libs/ tree in the radarsimx-deps submodule
+                          release - radarsimx-deps GitHub release archives (needs network)
     --cmake-args=ARGS   Additional CMake arguments
 
 EXAMPLES:
     $0                                  # Default build
     $0 --license=on --arch=gpu        # GPU build with license verification
     $0 --jobs=4 --verbose              # Parallel build with verbose output
+    $0 --deps=release                  # Download prebuilt dependencies from a release
     $0 --cmake-args="-DCUSTOM_FLAG=ON" # Custom CMake arguments
 
 PLATFORM-SPECIFIC NOTES:
@@ -397,6 +406,7 @@ check_requirements() {
 #   JOBS - Number of parallel build jobs
 #   CLEAN - Clean build artifacts flag (true/false)
 #   VERBOSE - Verbose output flag (true/false)
+#   DEPS - Prebuilt dependency source (repo/release)
 #   CMAKE_ARGS - Additional CMake arguments
 # Supported Options:
 #   --help: Shows help and exits
@@ -406,6 +416,7 @@ check_requirements() {
 #   --jobs=VALUE: Sets parallel job count
 #   --clean=VALUE: Enables/disables cleanup
 #   --verbose: Enables verbose output
+#   --deps=VALUE: Selects the prebuilt dependency source
 #   --cmake-args=VALUE: Passes additional CMake arguments
 # Exit:
 #   Exits with code 0 on --help
@@ -418,10 +429,11 @@ parse_arguments() {
     JOBS=""                # Number of parallel jobs (auto-detect if empty)
     CLEAN="true"           # Clean build artifacts before building
     VERBOSE="true"        # Enable verbose output
+    DEPS="repo"            # Prebuilt dependency source (repo/release)
     CMAKE_ARGS=""          # Additional CMake arguments
-    
+
     # Parse command line arguments
-    # Supports --help, --license, --arch, --test, --jobs, --clean, --verbose, and --cmake-args parameters
+    # Supports --help, --license, --arch, --test, --jobs, --clean, --verbose, --deps, and --cmake-args parameters
     for i in "$@"; do
         case $i in
             --help*)
@@ -450,6 +462,10 @@ parse_arguments() {
                 ;;
             --verbose*)
                 VERBOSE="true"
+                shift
+                ;;
+            --deps=*)
+                DEPS="${i#*=}"
                 shift
                 ;;
             --cmake-args=*)
@@ -487,12 +503,14 @@ parse_arguments() {
 #   TEST - Validated against 'on' and 'off'
 #   JOBS - Validated as positive integer
 #   CLEAN - Validated against 'true' and 'false'
+#   DEPS - Validated against 'repo' and 'release'
 # Validation Rules:
 #   - LICENSE: Must be 'on' or 'off' (case insensitive)
 #   - ARCH: Must be 'cpu' or 'gpu' (case insensitive)
 #   - TEST: Must be 'on' or 'off' (case insensitive)
 #   - JOBS: Must be positive integer >= 1
 #   - CLEAN: Must be 'true' or 'false' (case insensitive)
+#   - DEPS: Must be 'repo' or 'release' (case insensitive)
 # Exit:
 #   Exits with code 1 if any validation errors are found
 validate_parameters() {
@@ -543,7 +561,17 @@ validate_parameters() {
             errors=$((errors + 1))
             ;;
     esac
-    
+
+    # Validate prebuilt dependency source parameter
+    deps_lower=$(echo "${DEPS}" | tr '[:upper:]' '[:lower:]')
+    case "${deps_lower}" in
+        "repo"|"release") ;;
+        *)
+            log_error "Invalid --deps parameter: '$DEPS'. Choose 'repo' or 'release'"
+            errors=$((errors + 1))
+            ;;
+    esac
+
     if [ $errors -gt 0 ]; then
         log_error "Parameter validation failed with $errors error(s)"
         exit 1
@@ -568,6 +596,7 @@ validate_parameters() {
 #   JOBS - Number of parallel jobs
 #   CLEAN - Clean build setting
 #   VERBOSE - Verbose output setting
+#   DEPS - Prebuilt dependency source
 #   LOG_FILE - Log file path
 #   CMAKE_ARGS - Additional CMake arguments (if any)
 # Output:
@@ -596,6 +625,7 @@ display_banner() {
     echo "  - Parallel Jobs: ${JOBS}"
     echo "  - Clean Build: $(echo "${CLEAN}" | tr '[:lower:]' '[:upper:]')"
     echo "  - Verbose: $(echo "${VERBOSE}" | tr '[:lower:]' '[:upper:]')"
+    echo "  - Prebuilt Dependencies: $(echo "${DEPS}" | tr '[:lower:]' '[:upper:]')"
     echo "  - Log File: ${LOG_FILE}"
     [ -n "$CMAKE_ARGS" ] && echo "  - CMake Args: ${CMAKE_ARGS}"
     echo
@@ -667,6 +697,7 @@ clean_build_artifacts() {
 #   ARCH - Determines GPU build flags
 #   LICENSE - Determines ENABLE_LICENSE build flag
 #   TEST - Controls Google Test compilation
+#   DEPS - Determines RADARSIMCPP_DEPS_PREFER_DOWNLOAD build flag
 #   CMAKE_ARGS - Additional CMake arguments
 #   JOBS - Number of parallel compilation jobs
 #   VERBOSE - Controls build output verbosity
@@ -683,6 +714,7 @@ clean_build_artifacts() {
 #   - GPU_BUILD=ON (if ARCH=gpu)
 #   - ENABLE_LICENSE=ON/OFF (based on LICENSE setting)
 #   - GTEST=ON/OFF (based on TEST setting)
+#   - RADARSIMCPP_DEPS_PREFER_DOWNLOAD=ON/OFF (based on DEPS setting)
 #   - Custom flags from CMAKE_ARGS
 build_cpp_library() {
     local build_start=$(date +%s)
@@ -719,7 +751,17 @@ build_cpp_library() {
     else
         cmake_args+=" -DGTEST=OFF"
     fi
-    
+
+    # Select where the prebuilt third-party libraries come from. 'repo' uses the
+    # committed libs/ tree in the radarsimx-deps submodule and needs no network;
+    # 'release' downloads the checksum-pinned archives from the deps release.
+    deps_lower=$(echo "${DEPS}" | tr '[:upper:]' '[:lower:]')
+    if [ "${deps_lower}" = "release" ]; then
+        cmake_args+=" -DRADARSIMCPP_DEPS_PREFER_DOWNLOAD=ON"
+    else
+        cmake_args+=" -DRADARSIMCPP_DEPS_PREFER_DOWNLOAD=OFF"
+    fi
+
     # Add custom CMake arguments
     if [ -n "$CMAKE_ARGS" ]; then
         cmake_args+=" $CMAKE_ARGS"

--- a/build_instructions.md
+++ b/build_instructions.md
@@ -133,6 +133,7 @@ python build_config.py
 - `--arch`: Architecture (`cpu` or `gpu`)
 - `--test`: Enable testing (`on` or `off`)
 - `--license`: Enable license verification (`on` or `off`)
+- `--deps`: Prebuilt dependency source (`repo` or `release`)
 
 ## Ubuntu 22.04/24.04/26.04 and Other Linux Distributions
 
@@ -193,6 +194,7 @@ python build_config.py
 - `--arch`: Architecture (`cpu` or `gpu`)
 - `--test`: Enable testing (`on` or `off`)
 - `--license`: Enable license verification (`on` or `off`)
+- `--deps`: Prebuilt dependency source (`repo` or `release`)
 
 ## macOS
 
@@ -251,10 +253,42 @@ python build_config.py
 - `--arch`: Architecture (`cpu`)
 - `--test`: Enable testing (`on` or `off`)
 - `--license`: Enable license verification (`on` or `off`)
+- `--deps`: Prebuilt dependency source (`repo` or `release`)
 - `--jobs`: Number of parallel build jobs (auto-detected by default)
 - `--verbose`: Enable verbose output
 - `--clean`: Clean build artifacts (`true` or `false`)
 - `--cmake-args`: Additional CMake arguments
+
+## Prebuilt Dependency Source
+
+RadarSimCpp links third-party libraries (HDF5, and mbedTLS when license
+verification is enabled) as prebuilt static libraries. They are never compiled
+as part of a RadarSimPy build; `--deps` only chooses where they are read from.
+
+| `--deps` | Where the libraries come from | Network needed |
+|---|---|---|
+| `repo` (default) | The committed `libs/` tree in the `radarsimx-deps` submodule, reached through `src/radarsimcpp/deps` | No |
+| `release` | The checksum-pinned release archives published by [`radarsimx/radarsimx-deps`](https://github.com/radarsimx/radarsimx-deps), downloaded and cached under `src/radarsimcpp/.deps-cache/` | Yes, on the first build |
+
+```bash
+# Linux/macOS
+./build.sh --deps=release
+
+# Windows
+build.bat --deps=release
+```
+
+`repo` is the default because it needs no network and pins the dependencies to
+the submodule commit, which makes it the right choice for local and offline
+builds. The GitHub Actions workflows all pass `--deps=release`, so CI links the
+same tagged, checksum-verified archives every time.
+
+Downloaded archives are verified against the SHA-256 checksums pinned in
+`src/radarsimcpp/cmake/deps_manifest.cmake`; a mismatch fails the build rather
+than linking something unverified. The cache lives outside the build directory,
+so a clean build does not re-download. Note that `--deps=release` only works
+for platforms that the pinned release actually published; if one is missing,
+the build stops with the reason instead of silently falling back.
 
 ## Building Documentation
 


### PR DESCRIPTION
RadarSimCpp can already resolve its prebuilt third-party libraries (HDF5,
mbedTLS) either from the committed libs/ tree in the radarsimx-deps
submodule or from that repository's checksum-pinned release archives, but
the RadarSimPy build scripts had no way to pick between them - every build
took the submodule path.

Expose the choice as --deps=<repo|release>, which maps onto the existing
RADARSIMCPP_DEPS_PREFER_DOWNLOAD CMake option:

  repo     the committed libs/ tree, no network at configure time
  release  the radarsimx-deps release archives, downloaded and verified
           against the SHA-256 checksums in deps_manifest.cmake, cached
           outside the build directory so a clean build does not refetch

The default stays 'repo' so local and offline builds are unchanged. All
GitHub Actions workflows now pass --deps=release, so CI links the same
tagged, checksum-verified archives on every run rather than whatever the
submodule happens to be pinned at.

build.bat's CMake invocation collapses from four near-identical branches
to a single flag list, which is what makes adding the new option there a
one-line change rather than a fourth copy.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M4TAw7ykCQzkFFUYE3RVsK