### PR TITLE
Add glTF 2.0 / GLB animated target support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `radarsimpy.animation_kit`, which turns a keyframe-animated glTF 2.0 / GLB model into ordinary target dictionaries. Each animated node becomes its own target whose `location`, `speed`, `rotation` and `rotation_rate` are sampled at `radar.time_prop["timestamp"]`, so a spinning rotor, a turning wheel or a keyframed flight path is simulated from the motion authored in the file instead of being re-derived by hand. Velocity and angular rate come from the analytic derivative of the keyframe interpolation, not from differencing the sample grid, because the timestamp restarts at every channel and frame. `STEP`, `LINEAR` and `CUBICSPLINE` samplers, nested node hierarchies and the glTF Y-up to RadarSimPy Z-up conversion are handled; skinning, morph targets and animated scale raise a descriptive `NotImplementedError`, since the ray tracer transforms each target rigidly. Requires the optional `pygltflib` package, discovered at runtime the same way the mesh backends are
+- `radarsimpy.mesh_kit.load_mesh` accepts an in-memory `{"points": ..., "cells": ...}` dictionary in place of a file path, so generated geometry can be simulated without a temporary file. This is how `animation_kit` hands over the parts it extracts from an animated model
+- `gltf` pytest marker, which skips the animated-model tests when `pygltflib` is not installed
 - `benchmarks/bench_sbr.py`, a timing harness for the mesh (SBR) simulator. Sweeps the parameters that drive ray-tracing cost -- `density`, `level`, transmit/receive channel count, model, pulse count -- writes a self-describing JSON record, and turns two such records into a speedup table with `--compare`. `--omp-scaling` re-runs the sweeps in a subprocess per `OMP_NUM_THREADS` value, which is the only way to vary it (the OpenMP runtime reads it at load time) and the measurement that distinguishes real parallel speedup from lock contention
 - `benchmarks/capture_reference.py`, which records the baseband of six scenes chosen to exercise distinct code paths and diffs a fresh capture against a saved one, so a change to the tracer can be reviewed as a numerical delta instead of a wall of failing asserts
 - `benchmarks/baseline/`, holding the pre-optimization CPU and GPU sweeps and reference captures
@@ -19,6 +22,10 @@ All notable changes to this project will be documented in this file.
 - `--deps` build option (`build.sh` / `build.bat`) selecting where the prebuilt third-party libraries come from: `repo` (default) reads the committed `libs/` tree in the `radarsimx-deps` submodule and needs no network, `release` downloads the checksum-pinned `radarsimx-deps` GitHub release archives into a cache outside the build directory. All GitHub Actions workflows now build with `--deps=release`
 - Runtime CPU fallback for machines without a GPU. The execution policies resolve at compile time, so a GPU-enabled build would attempt CUDA execution even where no device exists; `sim_radar`, `sim_rcs` and `sim_lidar` now probe for a usable CUDA device and dispatch to the CPU policy when there is none. `sim_radar(device="gpu")` reports the fallback as a `RuntimeWarning`. A CPU-only build is unaffected, and an explicit `device="cpu"` request is unchanged
 - CPU fallback test suite (`test_system_cpu_fallback.py`)
+
+### Fixed
+
+- `radarsimpy.mesh_kit.import_mesh_module` docstring listed the backend search order as pyvista first; the code has always tried trimesh first
 
 ### Changed
 

--- a/gen_docs/api/animation.rst
+++ b/gen_docs/api/animation.rst
@@ -1,0 +1,5 @@
+Animated 3D Models
+==================
+
+.. automodule:: radarsimpy.animation_kit
+    :members: import_gltf_module, load_animated_model, load_animated_targets

--- a/gen_docs/api/index.rst
+++ b/gen_docs/api/index.rst
@@ -9,3 +9,4 @@ API
    process
    tools
    scene
+   animation

--- a/gen_docs/user_guide/animated_targets.rst
+++ b/gen_docs/user_guide/animated_targets.rst
@@ -1,0 +1,186 @@
+Animated Targets (glTF 2.0 / GLB)
+==================================
+
+A target's motion is normally written by hand as ``speed`` and ``rotation_rate``
+in its target dictionary. That works for a rigid body moving at a constant
+velocity and a constant rate, but many 3D assets already carry their motion
+inside the file: a drone with spinning rotors, a wind turbine, a car with
+turning wheels, or any object following a keyframed path.
+
+:mod:`radarsimpy.animation_kit` reads that motion from a **glTF 2.0 / GLB**
+model and turns it into ordinary target dictionaries, so nothing else about
+your simulation changes.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    import radarsimpy
+    from radarsimpy.animation_kit import load_animated_targets
+    from radarsimpy.simulator import sim_radar
+
+    radar = radarsimpy.Radar(transmitter=tx, receiver=rx)
+
+    targets = load_animated_targets(
+        "turbine.glb",
+        radar,
+        location=(80, 0, 0),
+        permittivity="PEC",
+    )
+
+    data = sim_radar(radar, targets)
+
+``load_animated_targets`` returns a plain ``list`` of target dictionaries. You
+can inspect them, edit them, or mix them with hand-written targets before
+passing them to :func:`radarsimpy.sim_radar`.
+
+Install the optional parser first:
+
+.. code-block:: bash
+
+    pip install pygltflib
+
+How the mapping works
+---------------------
+
+**One target per animated node.** Every glTF node that an animation channel
+targets becomes its own RadarSimPy target. Geometry beneath a node is grouped
+into the nearest animated ancestor, so each target moves as one rigid body.
+Meshes with no animated ancestor are merged into a single static target
+(``merge_static=False`` keeps them separate).
+
+**Motion is sampled at the radar's own timestamps.** The node's world pose is
+evaluated at every entry of ``radar.time_prop["timestamp"]`` and emitted as
+time-varying ``location`` and ``rotation`` arrays, exactly the form the
+simulator already accepts for hand-written motion.
+
+**Velocity is analytic, not differenced.** ``speed`` and ``rotation_rate`` are
+taken from the derivative of the keyframe interpolation itself. RadarSimCpp
+derives hit-point velocity from those two keys rather than from successive
+positions, so getting them right is what makes the Doppler correct.
+
+**Frames are converted.** glTF is Y-up; RadarSimPy is Z-up (see
+:doc:`coordinate`). Geometry, poses and rates are rotated accordingly. Pass
+``up_axis="z"`` for an asset already exported Z-up.
+
+Placing and driving the whole model
+-----------------------------------
+
+The ``location``, ``rotation``, ``speed`` and ``rotation_rate`` arguments place
+and drive the complete model on top of its internal animation. A drone flying
+past while its rotors spin is:
+
+.. code-block:: python
+
+    targets = load_animated_targets(
+        "drone.glb",
+        radar,
+        location=(60, -20, 15),
+        speed=(0, 12, 0),
+    )
+
+Controlling playback
+--------------------
+
+.. code-block:: python
+
+    targets = load_animated_targets(
+        "walk.glb", radar,
+        animation="walk_cycle",  # name or index; default is the first clip
+        time_offset=0.3,         # animation time at simulation time zero
+        time_scale=1.5,          # play the clip 1.5x faster
+        loop=True,               # wrap when the simulation outlasts the clip
+    )
+
+With ``loop=False`` the first and last poses are held instead, and the rates go
+to zero outside the clip.
+
+Static snapshots for RCS and lidar
+-----------------------------------
+
+:func:`radarsimpy.sim_rcs` and :func:`radarsimpy.sim_lidar` do not accept
+time-varying motion. Ask for a single instant instead, which returns targets
+with ordinary scalar motion:
+
+.. code-block:: python
+
+    targets = load_animated_targets("turbine.glb", at_time=0.25)
+    rcs = sim_rcs(targets, f=77e9, inc_phi=0, inc_theta=90)
+
+Inspecting the parts
+--------------------
+
+:func:`radarsimpy.animation_kit.load_animated_model` exposes the split without
+sampling anything, which is useful for checking how a model decomposes:
+
+.. code-block:: python
+
+    model = load_animated_model("drone.glb")
+    print(model["animations"], model["duration"])
+    for part in model["parts"]:
+        print(part["name"], part["animated"], len(part["cells"]), "faces")
+
+Animated targets also work with
+:func:`radarsimpy.mesh_kit.get_target_mesh` and
+:func:`radarsimpy.get_scene_state`, so you can plot the transformed geometry at
+any query time.
+
+What is supported
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Feature
+     - Status
+   * - ``.gltf`` and ``.glb``
+     - Supported
+   * - Node ``translation`` / ``rotation`` animation
+     - Supported
+   * - ``STEP``, ``LINEAR`` and ``CUBICSPLINE`` interpolation
+     - Supported
+   * - Nested node hierarchies
+     - Supported
+   * - Uniform, constant scale
+     - Supported (baked into the geometry)
+   * - Skinning (``skins``, ``JOINTS_0`` / ``WEIGHTS_0``)
+     - Not supported
+   * - Morph targets (``weights`` animation)
+     - Not supported
+   * - Animated scale
+     - Not supported
+   * - Non-uniform scale on an animated node
+     - Not supported
+   * - Non-triangle primitives
+     - Not supported
+
+The unsupported cases all move individual vertices, while the ray tracer
+transforms each target rigidly. They raise a descriptive
+``NotImplementedError`` rather than producing a silently wrong result. To
+simulate a deforming object such as a walking pedestrian, split it into rigid
+parts and animate their nodes instead.
+
+Limitations to keep in mind
+---------------------------
+
+**Memory.** Each animated part allocates twelve ``float32`` arrays the size of
+``radar.time_prop["timestamp"]``. For a 4-channel, 256-pulse, 512-sample record
+that is roughly 25 MB per part, so a twenty-part model approaches 500 MB. This
+is inherent to the time-varying motion path, whose arrays must match the
+baseband time matrix. Merge parts that do not move independently to reduce it.
+
+**Gimbal lock.** Poses are emitted as ``[yaw, pitch, roll]``. At a pitch of
+±90° the yaw and roll split becomes ambiguous, and a warning is issued. Avoid
+authoring motion that passes exactly through the pole.
+
+**Trial-version mesh limit.** The face-count cap applies per target, and each
+animated part is its own target.
+
+See Also
+--------
+
+* :doc:`coordinate` - The Z-up frame and the yaw/pitch/roll convention
+* :doc:`ray_tracing_simulation` - How mesh targets are simulated
+* :doc:`dependence` - Optional package requirements

--- a/gen_docs/user_guide/dependence.rst
+++ b/gen_docs/user_guide/dependence.rst
@@ -26,6 +26,17 @@ For 3D object simulation and RCS calculation, at least one of the following mesh
 .. note::
    You only need to install one mesh processing library. ``trimesh`` is recommended for most users due to its simplicity and minimal dependencies.
 
+**Animated 3D Models**
+
+To load keyframe-animated glTF 2.0 / GLB models with :mod:`radarsimpy.animation_kit`, install:
+
+* **pygltflib** >= 1.16.0 - glTF 2.0 / GLB parsing
+
+.. note::
+   This is only needed for animated models. Static ``.stl``, ``.ply`` and ``.obj``
+   files are handled by the mesh processing library above. See
+   :doc:`animated_targets`.
+
 **Installation**
 
 Install all required dependencies using:
@@ -39,6 +50,12 @@ Or install individually:
 .. code-block:: bash
 
     pip install numpy scipy trimesh
+
+For animated glTF models:
+
+.. code-block:: bash
+
+    pip install pygltflib
 
 System Requirements
 -------------------
@@ -140,4 +157,5 @@ See Also
 --------
 
 * :doc:`installation` - Installation instructions
+* :doc:`animated_targets` - Simulating keyframe-animated 3D models
 * :doc:`build` - Building from source (for developers with source access)

--- a/gen_docs/user_guide/index.rst
+++ b/gen_docs/user_guide/index.rst
@@ -13,5 +13,6 @@ User Guide
    noise
    range_gate
    ray_tracing_simulation
+   animated_targets
    examples
    build

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ addopts =
 
 markers =
     mesh: requires an optional mesh-processing library (trimesh/pyvista/pymeshlab/meshio)
+    gltf: requires the optional glTF library (pygltflib)
     slow: long-running simulation, deselect with '-m "not slow"'
 
 filterwarnings =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,9 @@ pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-xdist>=3.0.0
 
+# Optional runtime dependency exercised by the test suite
+pygltflib>=1.16.0
+
 # Code Quality
 black>=22.0.0
 flake8>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,9 @@ scipy>=1.9.0
 # pyvista>=0.36.0        # 3D visualization and mesh processing
 # meshio>=5.0.0          # Mesh I/O operations
 
+# Optional Dependency for Animated 3D Models
+# Install for glTF 2.0 / GLB keyframe animation support (radarsimpy.animation_kit):
+# pygltflib>=1.16.0      # glTF 2.0 / GLB parsing
+
 # Currently included for basic mesh support
 trimesh>=3.15.0

--- a/src/radarsimpy/__init__.py
+++ b/src/radarsimpy/__init__.py
@@ -60,6 +60,9 @@ from . import tools
 # 3D mesh utilities
 from . import mesh_kit
 
+# Animated 3D model (glTF 2.0 / GLB) utilities
+from . import animation_kit
+
 # Scene state retrieval
 from .scene import get_scene_state
 
@@ -104,6 +107,7 @@ __all__ = [
     "processing",
     "tools",
     "mesh_kit",
+    "animation_kit",
     # Metadata
     "__version__",
     "__author__",

--- a/src/radarsimpy/animation_kit.py
+++ b/src/radarsimpy/animation_kit.py
@@ -1,0 +1,1558 @@
+"""
+Script for loading animated 3D models (glTF 2.0 / GLB)
+
+This script turns a keyframe-animated glTF 2.0 or GLB file into ordinary
+RadarSimPy target dictionaries. Each animated node of the model becomes its own
+target carrying per-timestamp ``location``/``speed``/``rotation``/
+``rotation_rate`` arrays sampled at ``radar.time_prop["timestamp"]``, so a
+spinning rotor, a turning wheel or a keyframed flight path is simulated with
+the motion authored in the 3D file rather than re-derived by hand.
+
+Only rigid node animation is supported. Skinning, morph targets and animated
+scale would require per-timestep vertex geometry, which the ray tracer does not
+model; those inputs raise a descriptive error.
+
+---
+
+- Copyright (C) 2018 - PRESENT  radarsimx.com
+- E-mail: info@radarsimx.com
+- Website: https://radarsimx.com
+
+::
+
+    ██████╗  █████╗ ██████╗  █████╗ ██████╗ ███████╗██╗███╗   ███╗██╗  ██╗
+    ██╔══██╗██╔══██╗██╔══██╗██╔══██╗██╔══██╗██╔════╝██║████╗ ████║╚██╗██╔╝
+    ██████╔╝███████║██║  ██║███████║██████╔╝███████╗██║██╔████╔██║ ╚███╔╝
+    ██╔══██╗██╔══██║██║  ██║██╔══██║██╔══██╗╚════██║██║██║╚██╔╝██║ ██╔██╗
+    ██║  ██║██║  ██║██████╔╝██║  ██║██║  ██║███████║██║██║ ╚═╝ ██║██╔╝ ██╗
+    ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝
+
+"""
+
+# pylint: disable=too-many-lines
+
+import warnings
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .mesh_kit import check_module_installed, safe_import
+
+__all__ = [
+    "import_gltf_module",
+    "load_animated_model",
+    "load_animated_targets",
+]
+
+
+# =============================================================================
+# glTF constants
+# =============================================================================
+
+#: glTF ``componentType`` enum to numpy dtype.
+_COMPONENT_DTYPE = {
+    5120: np.int8,
+    5121: np.uint8,
+    5122: np.int16,
+    5123: np.uint16,
+    5125: np.uint32,
+    5126: np.float32,
+}
+
+#: Normalisation divisor for integer component types read as ``normalized``.
+_COMPONENT_NORM = {
+    5120: 127.0,
+    5121: 255.0,
+    5122: 32767.0,
+    5123: 65535.0,
+}
+
+#: glTF accessor ``type`` to component count.
+_TYPE_COUNT = {
+    "SCALAR": 1,
+    "VEC2": 2,
+    "VEC3": 3,
+    "VEC4": 4,
+    "MAT2": 4,
+    "MAT3": 9,
+    "MAT4": 16,
+}
+
+#: glTF primitive mode for triangles; the only mode a facet ray tracer accepts.
+_MODE_TRIANGLES = 4
+
+#: File-unit name to the divisor that converts stored values to meters.
+UNIT_SCALE = {"m": 1.0, "cm": 100.0, "mm": 1000.0}
+
+#: Rotation carrying glTF's Y-up frame into RadarSimPy's Z-up frame (+90 deg
+#: about x), as a quaternion in ``(x, y, z, w)`` order.
+_Q_YUP_TO_ZUP = np.array([np.sqrt(0.5), 0.0, 0.0, np.sqrt(0.5)])
+
+#: Identity quaternion in ``(x, y, z, w)`` order.
+_Q_IDENTITY = np.array([0.0, 0.0, 0.0, 1.0])
+
+
+# =============================================================================
+# Module discovery
+# =============================================================================
+
+
+def import_gltf_module() -> object:
+    """
+    Import the glTF parsing module used to read animated models
+
+    :return: The ``pygltflib`` module object
+    :rtype: object
+    :raises ImportError: If ``pygltflib`` is not installed
+    """
+    if check_module_installed("pygltflib"):
+        module = safe_import("pygltflib")
+        if module is not None:
+            return module
+
+    raise ImportError(
+        "\nglTF Processing Module Required\n"
+        "-------------------------------\n"
+        "Reading animated 3D models requires the 'pygltflib' package.\n\n"
+        "Please install it with:\n"
+        "    • pip install pygltflib\n"
+    )
+
+
+# =============================================================================
+# Quaternion helpers
+#
+# Quaternions are stored in glTF's ``(x, y, z, w)`` order throughout. Every
+# helper broadcasts over leading axes, so a whole time series is handled in one
+# call.
+# =============================================================================
+
+
+def _quat_multiply(quat_a: NDArray, quat_b: NDArray) -> NDArray:
+    """
+    Hamilton product ``quat_a * quat_b``
+
+    :param numpy.ndarray quat_a: Left quaternion(s), shape ``[..., 4]``
+    :param numpy.ndarray quat_b: Right quaternion(s), shape ``[..., 4]``
+
+    :return: The product, shape ``[..., 4]``
+    :rtype: numpy.ndarray
+    """
+    a_x, a_y, a_z, a_w = (quat_a[..., i] for i in range(4))
+    b_x, b_y, b_z, b_w = (quat_b[..., i] for i in range(4))
+    return np.stack(
+        (
+            a_w * b_x + a_x * b_w + a_y * b_z - a_z * b_y,
+            a_w * b_y - a_x * b_z + a_y * b_w + a_z * b_x,
+            a_w * b_z + a_x * b_y - a_y * b_x + a_z * b_w,
+            a_w * b_w - a_x * b_x - a_y * b_y - a_z * b_z,
+        ),
+        axis=-1,
+    )
+
+
+def _quat_conjugate(quat: NDArray) -> NDArray:
+    """
+    Conjugate (inverse, for unit quaternions)
+
+    :param numpy.ndarray quat: Quaternion(s), shape ``[..., 4]``
+
+    :return: The conjugate, shape ``[..., 4]``
+    :rtype: numpy.ndarray
+    """
+    out = np.array(quat, dtype=np.float64, copy=True)
+    out[..., :3] *= -1.0
+    return out
+
+
+def _quat_normalize(quat: NDArray) -> NDArray:
+    """
+    Normalise to unit length, leaving degenerate quaternions as identity
+
+    :param numpy.ndarray quat: Quaternion(s), shape ``[..., 4]``
+
+    :return: Unit quaternion(s), shape ``[..., 4]``
+    :rtype: numpy.ndarray
+    """
+    quat = np.asarray(quat, dtype=np.float64)
+    norm = np.linalg.norm(quat, axis=-1, keepdims=True)
+    return np.where(norm > 0.0, quat / np.where(norm > 0.0, norm, 1.0), _Q_IDENTITY)
+
+
+def _quat_rotate(quat: NDArray, vec: NDArray) -> NDArray:
+    """
+    Rotate vectors by unit quaternions
+
+    :param numpy.ndarray quat: Unit quaternion(s), shape ``[..., 4]``
+    :param numpy.ndarray vec: Vector(s), shape ``[..., 3]``
+
+    :return: The rotated vector(s), shape ``[..., 3]``
+    :rtype: numpy.ndarray
+    """
+    axis = quat[..., :3]
+    scalar = quat[..., 3:4]
+    cross1 = np.cross(axis, vec)
+    return vec + 2.0 * (scalar * cross1 + np.cross(axis, cross1))
+
+
+def _quat_to_rsx_euler(quat: NDArray) -> NDArray:
+    """
+    Convert quaternions to RadarSimPy ``[yaw, pitch, roll]`` angles
+
+    RadarSimPy's ``GetRotateParams`` builds ``R = Rz(yaw) Ry(-pitch) Rx(roll)``,
+    which puts ``sin(pitch)`` at ``R[2][0]``. This inverts that exact form, so
+    the angles round-trip through the C++ transform.
+
+    :param numpy.ndarray quat: Unit quaternion(s), shape ``[..., 4]``
+
+    :return: Angles in radians, shape ``[..., 3]`` as ``[yaw, pitch, roll]``
+    :rtype: numpy.ndarray
+    """
+    q_x, q_y, q_z, q_w = (quat[..., i] for i in range(4))
+
+    r20 = 2.0 * (q_x * q_z - q_y * q_w)
+    r10 = 2.0 * (q_x * q_y + q_z * q_w)
+    r00 = 1.0 - 2.0 * (q_y * q_y + q_z * q_z)
+    r21 = 2.0 * (q_y * q_z + q_x * q_w)
+    r22 = 1.0 - 2.0 * (q_x * q_x + q_y * q_y)
+
+    pitch = np.arcsin(np.clip(r20, -1.0, 1.0))
+    yaw = np.arctan2(r10, r00)
+    roll = np.arctan2(r21, r22)
+
+    if np.any(np.abs(r20) > 0.9999):
+        warnings.warn(
+            "Animated model reaches a pitch of +/-90 degrees, where the "
+            "yaw/pitch/roll representation is singular. Yaw and roll may be "
+            "split arbitrarily between the two axes at those instants.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    return np.stack((yaw, pitch, roll), axis=-1)
+
+
+def _rsx_euler_to_quat(rotation: Sequence[float]) -> NDArray:
+    """
+    Convert RadarSimPy ``[yaw, pitch, roll]`` angles to a quaternion
+
+    :param rotation: Angles in radians as ``[yaw, pitch, roll]``
+
+    :return: Unit quaternion in ``(x, y, z, w)`` order, shape ``[3 -> 4]``
+    :rtype: numpy.ndarray
+    """
+    yaw, pitch, roll = (float(value) for value in rotation)
+
+    half_yaw, half_pitch, half_roll = yaw / 2.0, -pitch / 2.0, roll / 2.0
+    quat_z = np.array([0.0, 0.0, np.sin(half_yaw), np.cos(half_yaw)])
+    quat_y = np.array([0.0, np.sin(half_pitch), 0.0, np.cos(half_pitch)])
+    quat_x = np.array([np.sin(half_roll), 0.0, 0.0, np.cos(half_roll)])
+
+    return _quat_multiply(_quat_multiply(quat_z, quat_y), quat_x)
+
+
+def _angular_velocity(quat: NDArray, quat_dot: NDArray) -> NDArray:
+    """
+    Body-frame angular velocity from a quaternion and its time derivative
+
+    :param numpy.ndarray quat: Unit quaternion(s), shape ``[..., 4]``
+    :param numpy.ndarray quat_dot: Time derivative(s), shape ``[..., 4]``
+
+    :return: Angular velocity in the body frame, shape ``[..., 3]``
+    :rtype: numpy.ndarray
+    """
+    return 2.0 * _quat_multiply(_quat_conjugate(quat), quat_dot)[..., :3]
+
+
+# =============================================================================
+# Accessor decoding
+# =============================================================================
+
+
+def _resolve_blob(gltf: Any, gltf_module: Any) -> bytes:
+    """
+    Return the model's binary data as a single blob
+
+    Normalises GLB payloads, embedded data URIs and external ``.bin`` files to
+    one buffer so a single accessor decoder covers every variant.
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param gltf_module: The ``pygltflib`` module
+
+    :return: The binary blob backing every buffer view
+    :rtype: bytes
+    """
+    if not gltf.buffers:
+        return b""
+
+    if len(gltf.buffers) > 1:
+        raise NotImplementedError(
+            "Multi-buffer glTF files are not supported. Re-export the model as "
+            "a single-buffer .glb."
+        )
+
+    gltf.convert_buffers(gltf_module.BufferFormat.BINARYBLOB)
+    blob = gltf.binary_blob()
+    if blob is None:
+        raise RuntimeError("glTF file contains no readable binary buffer data.")
+    return blob
+
+
+def _read_accessor(gltf: Any, blob: bytes, index: int) -> NDArray:
+    """
+    Decode one glTF accessor into a numpy array
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param bytes blob: Binary data from :func:`_resolve_blob`
+    :param int index: Accessor index
+
+    :return: Decoded values, shape ``[count, components]``
+    :rtype: numpy.ndarray
+    """
+    accessor = gltf.accessors[index]
+
+    if getattr(accessor, "sparse", None) is not None:
+        raise NotImplementedError(
+            "Sparse glTF accessors are not supported. Re-export the model "
+            "without sparse accessors."
+        )
+
+    n_comp = _TYPE_COUNT[accessor.type]
+    dtype = np.dtype(_COMPONENT_DTYPE[accessor.componentType]).newbyteorder("<")
+
+    if accessor.bufferView is None:
+        # The spec says a missing bufferView means all-zero data.
+        return np.zeros((accessor.count, n_comp), dtype=np.float64)
+
+    view = gltf.bufferViews[accessor.bufferView]
+    start = (view.byteOffset or 0) + (accessor.byteOffset or 0)
+    packed = dtype.itemsize * n_comp
+    stride = view.byteStride or packed
+
+    if stride == packed:
+        values = np.frombuffer(
+            blob, dtype=dtype, count=accessor.count * n_comp, offset=start
+        ).reshape(accessor.count, n_comp)
+    else:
+        span = (accessor.count - 1) * stride + packed
+        raw = np.frombuffer(blob, dtype=np.uint8, count=span, offset=start)
+        rows = np.lib.stride_tricks.as_strided(
+            raw, shape=(accessor.count, packed), strides=(stride, 1)
+        )
+        values = np.ascontiguousarray(rows).view(dtype).reshape(accessor.count, n_comp)
+
+    values = values.astype(np.float64)
+    if getattr(accessor, "normalized", False):
+        divisor = _COMPONENT_NORM.get(accessor.componentType)
+        if divisor is not None:
+            values = np.maximum(values / divisor, -1.0)
+
+    return values
+
+
+# =============================================================================
+# Keyframe tracks
+# =============================================================================
+
+
+class _Track:  # pylint: disable=too-few-public-methods
+    """
+    One animation channel: keyframe times, values and an interpolation mode
+
+    Evaluation returns both the value and its analytic time derivative. The
+    derivative is taken from the interpolation itself rather than by
+    differencing the sampled grid, because ``radar.time_prop["timestamp"]``
+    is not monotonic across channels or frames and differencing it would spike
+    at every boundary.
+
+    :param numpy.ndarray times: Keyframe times (s), shape ``[n]``
+    :param numpy.ndarray values: Keyframe values, shape ``[n, c]`` (``[3n, c]``
+        for ``CUBICSPLINE``, which stores in-tangent/value/out-tangent triples)
+    :param str interpolation: ``STEP``, ``LINEAR`` or ``CUBICSPLINE``
+    :param bool is_quaternion: Whether the values are rotation quaternions
+    """
+
+    def __init__(
+        self,
+        times: NDArray,
+        values: NDArray,
+        interpolation: str,
+        is_quaternion: bool,
+    ):
+        self.times = np.asarray(times, dtype=np.float64).reshape(-1)
+        self.interpolation = (interpolation or "LINEAR").upper()
+        self.is_quaternion = is_quaternion
+
+        values = np.asarray(values, dtype=np.float64)
+        if self.interpolation == "CUBICSPLINE":
+            values = values.reshape(len(self.times), 3, -1)
+        else:
+            values = values.reshape(len(self.times), -1)
+
+        if is_quaternion:
+            # Make consecutive keys take the shorter arc, so slerp does not
+            # spin the long way around and the derived rate keeps its sign.
+            values = self._align_quaternion_signs(values)
+
+        self.values = values
+
+    @staticmethod
+    def _align_quaternion_signs(values: NDArray) -> NDArray:
+        """
+        Flip keyframe quaternions so consecutive keys stay on the same hemisphere
+
+        :param numpy.ndarray values: Keyframe values, shape ``[n, 4]`` or
+            ``[n, 3, 4]``
+
+        :return: Sign-aligned values with the same shape
+        :rtype: numpy.ndarray
+        """
+        values = values.copy()
+        spline = values.ndim == 3
+        for idx in range(1, values.shape[0]):
+            previous = values[idx - 1, 1] if spline else values[idx - 1]
+            current = values[idx, 1] if spline else values[idx]
+            if float(np.dot(previous, current)) < 0.0:
+                values[idx] *= -1.0
+        return values
+
+    def _segments(self, times: NDArray) -> Tuple[NDArray, NDArray, NDArray]:
+        """
+        Locate each query time inside the keyframe list
+
+        :param numpy.ndarray times: Query times (s), shape ``[k]``
+
+        :return: ``(left_index, right_index, normalised_position)``
+        :rtype: tuple
+        """
+        n_keys = len(self.times)
+        if n_keys == 1:
+            zeros = np.zeros(times.shape, dtype=np.intp)
+            return zeros, zeros, np.zeros(times.shape)
+
+        right = np.clip(np.searchsorted(self.times, times, side="right"), 1, n_keys - 1)
+        left = right - 1
+        span = self.times[right] - self.times[left]
+        span = np.where(span > 0.0, span, 1.0)
+        # Clamping outside the keyframe range holds the end pose, per the spec.
+        frac = np.clip((times - self.times[left]) / span, 0.0, 1.0)
+        return left, right, frac
+
+    def evaluate(self, times: NDArray) -> Tuple[NDArray, NDArray]:
+        """
+        Sample the track and its time derivative
+
+        :param numpy.ndarray times: Query times (s), shape ``[k]``
+
+        :return: ``(value, d value / d t)``, each shaped ``[k, c]``
+        :rtype: tuple
+        """
+        times = np.asarray(times, dtype=np.float64)
+        left, right, frac = self._segments(times)
+
+        if len(self.times) == 1 or self.interpolation == "STEP":
+            value = self.values[left, 1] if self.values.ndim == 3 else self.values[left]
+            return np.array(value), np.zeros_like(value)
+
+        span = (self.times[right] - self.times[left])[..., None]
+        span = np.where(span > 0.0, span, 1.0)
+        # Outside the keyframe range the pose is held, so every rate is zero.
+        held = self._inside(times)[..., None]
+
+        if self.interpolation == "CUBICSPLINE":
+            value, value_dot = self._evaluate_cubicspline(left, right, frac, span)
+            value_dot = np.where(held, value_dot, 0.0)
+            if self.is_quaternion:
+                return self._normalize_with_derivative(value, value_dot)
+            return value, value_dot
+
+        if self.is_quaternion:
+            return self._evaluate_slerp(left, right, frac, span, held)
+
+        value_0 = self.values[left]
+        value_1 = self.values[right]
+        value = value_0 + (value_1 - value_0) * frac[..., None]
+        value_dot = np.where(held, (value_1 - value_0) / span, 0.0)
+        return value, value_dot
+
+    def _inside(self, times: NDArray) -> NDArray:
+        """
+        Mask of query times that fall within the keyframe range
+
+        :param numpy.ndarray times: Query times (s), shape ``[k]``
+
+        :return: Boolean mask, shape ``[k]``
+        :rtype: numpy.ndarray
+        """
+        return (times >= self.times[0]) & (times <= self.times[-1])
+
+    def _evaluate_cubicspline(
+        self, left: NDArray, right: NDArray, frac: NDArray, span: NDArray
+    ) -> Tuple[NDArray, NDArray]:
+        """
+        Evaluate a cubic Hermite segment and its derivative
+
+        :param numpy.ndarray left: Left keyframe indices
+        :param numpy.ndarray right: Right keyframe indices
+        :param numpy.ndarray frac: Normalised position inside the segment
+        :param numpy.ndarray span: Segment duration (s), shape ``[k, 1]``
+
+        :return: ``(value, d value / d t)``
+        :rtype: tuple
+        """
+        pos = frac[..., None]
+        pos_sq = pos * pos
+        pos_cu = pos_sq * pos
+
+        value_0 = self.values[left, 1]
+        out_tangent_0 = self.values[left, 2] * span
+        value_1 = self.values[right, 1]
+        in_tangent_1 = self.values[right, 0] * span
+
+        value = (
+            (2.0 * pos_cu - 3.0 * pos_sq + 1.0) * value_0
+            + (pos_cu - 2.0 * pos_sq + pos) * out_tangent_0
+            + (-2.0 * pos_cu + 3.0 * pos_sq) * value_1
+            + (pos_cu - pos_sq) * in_tangent_1
+        )
+        value_dot = (
+            (6.0 * pos_sq - 6.0 * pos) * value_0
+            + (3.0 * pos_sq - 4.0 * pos + 1.0) * out_tangent_0
+            + (-6.0 * pos_sq + 6.0 * pos) * value_1
+            + (3.0 * pos_sq - 2.0 * pos) * in_tangent_1
+        ) / span
+
+        return value, value_dot
+
+    def _evaluate_slerp(  # pylint: disable=too-many-locals
+        self,
+        left: NDArray,
+        right: NDArray,
+        frac: NDArray,
+        span: NDArray,
+        held: NDArray,
+    ) -> Tuple[NDArray, NDArray]:
+        """
+        Spherical linear interpolation of quaternions with its derivative
+
+        :param numpy.ndarray left: Left keyframe indices
+        :param numpy.ndarray right: Right keyframe indices
+        :param numpy.ndarray frac: Normalised position inside the segment
+        :param numpy.ndarray span: Segment duration (s), shape ``[k, 1]``
+        :param numpy.ndarray held: Mask of times inside the keyframe range,
+            shape ``[k, 1]``; the rate is zero outside it
+
+        :return: ``(quaternion, d quaternion / d t)``
+        :rtype: tuple
+        """
+        quat_0 = self.values[left]
+        quat_1 = self.values[right]
+
+        # Relative rotation, expressed in quat_0's body frame. Slerp advances
+        # about a fixed body axis, so the body-frame rate is constant.
+        relative = _quat_multiply(_quat_conjugate(quat_0), quat_1)
+        vec_norm = np.linalg.norm(relative[..., :3], axis=-1)
+        angle = 2.0 * np.arctan2(vec_norm, np.abs(relative[..., 3]))
+        safe_norm = np.where(vec_norm > 1e-12, vec_norm, 1.0)
+        axis = relative[..., :3] / safe_norm[..., None]
+        axis = np.where((vec_norm > 1e-12)[..., None], axis, 0.0)
+        # ``relative`` already takes the short arc via the keyframe sign
+        # alignment, but guard the per-segment sign too.
+        axis = axis * np.sign(
+            np.where(relative[..., 3:4] == 0.0, 1.0, relative[..., 3:4])
+        )
+
+        half = (angle * frac / 2.0)[..., None]
+        step = np.concatenate((axis * np.sin(half), np.cos(half)), axis=-1)
+        quat = _quat_multiply(quat_0, step)
+
+        rate_body = np.where(held, axis * (angle / span[..., 0])[..., None], 0.0)
+        quat_dot = 0.5 * _quat_multiply(
+            quat,
+            np.concatenate((rate_body, np.zeros_like(rate_body[..., :1])), axis=-1),
+        )
+        return _quat_normalize(quat), quat_dot
+
+    @staticmethod
+    def _normalize_with_derivative(
+        quat: NDArray, quat_dot: NDArray
+    ) -> Tuple[NDArray, NDArray]:
+        """
+        Normalise a quaternion and correct its derivative for the normalisation
+
+        ``CUBICSPLINE`` quaternion output is not unit length, so the derivative
+        of ``q/|q|`` must account for the changing magnitude.
+
+        :param numpy.ndarray quat: Raw quaternion(s), shape ``[..., 4]``
+        :param numpy.ndarray quat_dot: Raw derivative(s), shape ``[..., 4]``
+
+        :return: ``(unit quaternion, corrected derivative)``
+        :rtype: tuple
+        """
+        norm = np.linalg.norm(quat, axis=-1, keepdims=True)
+        norm = np.where(norm > 0.0, norm, 1.0)
+        unit = quat / norm
+        projection = np.sum(quat * quat_dot, axis=-1, keepdims=True)
+        return unit, quat_dot / norm - quat * projection / norm**3
+
+
+# =============================================================================
+# Scene graph
+# =============================================================================
+
+
+def _node_rest_pose(node: Any) -> Tuple[NDArray, NDArray, NDArray]:
+    """
+    Rest-pose translation, rotation and scale of one node
+
+    :param node: A glTF node
+
+    :return: ``(translation[3], quaternion[4], scale[3])``
+    :rtype: tuple
+    """
+    matrix = getattr(node, "matrix", None)
+    if matrix:
+        # glTF stores matrices column-major.
+        mat = np.asarray(matrix, dtype=np.float64).reshape(4, 4).T
+        translation = mat[:3, 3]
+        basis = mat[:3, :3]
+        scale = np.linalg.norm(basis, axis=0)
+        safe = np.where(scale > 0.0, scale, 1.0)
+        return translation, _quat_from_matrix(basis / safe), scale
+
+    translation = np.asarray(node.translation or (0.0, 0.0, 0.0), dtype=np.float64)
+    rotation = np.asarray(node.rotation or (0.0, 0.0, 0.0, 1.0), dtype=np.float64)
+    scale = np.asarray(node.scale or (1.0, 1.0, 1.0), dtype=np.float64)
+    return translation, _quat_normalize(rotation), scale
+
+
+def _quat_from_matrix(basis: NDArray) -> NDArray:
+    """
+    Convert an orthonormal 3x3 rotation matrix to a quaternion
+
+    :param numpy.ndarray basis: Rotation matrix, shape ``[3, 3]``
+
+    :return: Unit quaternion in ``(x, y, z, w)`` order
+    :rtype: numpy.ndarray
+    """
+    trace = float(np.trace(basis))
+    if trace > 0.0:
+        scale = np.sqrt(trace + 1.0) * 2.0
+        quat = np.array(
+            [
+                (basis[2, 1] - basis[1, 2]) / scale,
+                (basis[0, 2] - basis[2, 0]) / scale,
+                (basis[1, 0] - basis[0, 1]) / scale,
+                0.25 * scale,
+            ]
+        )
+    else:
+        axis = int(np.argmax(np.diag(basis)))
+        idx_1, idx_2 = (axis + 1) % 3, (axis + 2) % 3
+        scale = (
+            np.sqrt(1.0 + basis[axis, axis] - basis[idx_1, idx_1] - basis[idx_2, idx_2])
+            * 2.0
+        )
+        quat = np.zeros(4)
+        quat[axis] = 0.25 * scale
+        quat[idx_1] = (basis[idx_1, axis] + basis[axis, idx_1]) / scale
+        quat[idx_2] = (basis[idx_2, axis] + basis[axis, idx_2]) / scale
+        quat[3] = (basis[idx_2, idx_1] - basis[idx_1, idx_2]) / scale
+    return _quat_normalize(quat)
+
+
+def _build_hierarchy(gltf: Any) -> Tuple[Dict[int, Optional[int]], List[int]]:
+    """
+    Map every node to its parent and return the default scene's roots
+
+    :param gltf: The loaded ``GLTF2`` object
+
+    :return: ``(parent_of, roots)``
+    :rtype: tuple
+    :raises ValueError: If the node graph contains a cycle
+    """
+    parent_of: Dict[int, Optional[int]] = {}
+    scene_index = gltf.scene if gltf.scene is not None else 0
+    if gltf.scenes:
+        roots = list(gltf.scenes[scene_index].nodes or [])
+    else:
+        roots = list(range(len(gltf.nodes)))
+
+    stack = [(root, None) for root in reversed(roots)]
+    while stack:
+        index, parent = stack.pop()
+        if index in parent_of:
+            raise ValueError(
+                f"glTF node graph is not a tree: node {index} has more than one parent."
+            )
+        parent_of[index] = parent
+        for child in gltf.nodes[index].children or []:
+            stack.append((child, index))
+
+    return parent_of, roots
+
+
+def _select_animation(gltf: Any, animation: Optional[Union[int, str]]) -> Optional[int]:
+    """
+    Resolve an animation name or index to an index
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param animation: Animation name, index, or ``None`` for the first one
+
+    :return: The animation index, or ``None`` if the file has no animations
+    :rtype: int or None
+    :raises ValueError: If the requested animation does not exist
+    """
+    if not gltf.animations:
+        return None
+
+    if animation is None:
+        return 0
+
+    if isinstance(animation, (int, np.integer)):
+        index = int(animation)
+        if not 0 <= index < len(gltf.animations):
+            raise ValueError(
+                f"Animation index {index} is out of range; the model has "
+                f"{len(gltf.animations)} animation(s)."
+            )
+        return index
+
+    names = [clip.name for clip in gltf.animations]
+    if animation not in names:
+        raise ValueError(
+            f"Animation '{animation}' not found. Available animations: {names}"
+        )
+    return names.index(animation)
+
+
+def _collect_tracks(
+    gltf: Any, blob: bytes, animation_index: Optional[int]
+) -> Dict[int, Dict[str, _Track]]:
+    """
+    Decode every animation channel into per-node tracks
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param bytes blob: Binary data from :func:`_resolve_blob`
+    :param animation_index: Index of the animation to read, or ``None``
+
+    :return: ``{node index: {path: track}}``
+    :rtype: dict
+    :raises NotImplementedError: If a channel animates weights or scale
+    """
+    tracks: Dict[int, Dict[str, _Track]] = {}
+    if animation_index is None:
+        return tracks
+
+    clip = gltf.animations[animation_index]
+    for channel in clip.channels:
+        node = channel.target.node
+        path = channel.target.path
+        if node is None:
+            continue
+
+        if path == "weights":
+            raise NotImplementedError(
+                "Morph-target ('weights') animation is not supported: it "
+                "deforms the mesh, which the ray tracer treats as rigid. "
+                "Bake the deformation into separate rigid parts instead."
+            )
+        if path == "scale":
+            raise NotImplementedError(
+                "Animated scale is not supported: it deforms the mesh, which "
+                "the ray tracer treats as rigid."
+            )
+
+        sampler = clip.samplers[channel.sampler]
+        tracks.setdefault(node, {})[path] = _Track(
+            times=_read_accessor(gltf, blob, sampler.input),
+            values=_read_accessor(gltf, blob, sampler.output),
+            interpolation=sampler.interpolation,
+            is_quaternion=(path == "rotation"),
+        )
+
+    return tracks
+
+
+def _clip_time_range(tracks: Dict[int, Dict[str, _Track]]) -> Tuple[float, float]:
+    """
+    Earliest and latest keyframe time across every track
+
+    :param dict tracks: Tracks from :func:`_collect_tracks`
+
+    :return: ``(start, end)`` in seconds
+    :rtype: tuple
+    """
+    starts, ends = [], []
+    for node_tracks in tracks.values():
+        for track in node_tracks.values():
+            starts.append(track.times[0])
+            ends.append(track.times[-1])
+    if not starts:
+        return 0.0, 0.0
+    return float(min(starts)), float(max(ends))
+
+
+# =============================================================================
+# Geometry extraction
+# =============================================================================
+
+
+def _node_geometry(gltf: Any, blob: bytes, node: Any) -> Tuple[NDArray, NDArray]:
+    """
+    Concatenate the triangle geometry of one node's mesh
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param bytes blob: Binary data from :func:`_resolve_blob`
+    :param node: A glTF node
+
+    :return: ``(points[n, 3], cells[m, 3])`` in the node's own frame
+    :rtype: tuple
+    :raises NotImplementedError: If the mesh is skinned or not triangulated
+    """
+    if node.mesh is None:
+        return np.zeros((0, 3)), np.zeros((0, 3), dtype=np.int64)
+
+    if getattr(node, "skin", None) is not None:
+        raise NotImplementedError(
+            "Skinned meshes are not supported: skinning moves individual "
+            "vertices, while the ray tracer transforms each target rigidly. "
+            "Split the model into rigid parts and animate their nodes instead."
+        )
+
+    points_list, cells_list, offset = [], [], 0
+    for primitive in gltf.meshes[node.mesh].primitives:
+        mode = _MODE_TRIANGLES if primitive.mode is None else primitive.mode
+        if mode != _MODE_TRIANGLES:
+            raise NotImplementedError(
+                f"glTF primitive mode {mode} is not supported; only triangles "
+                "(mode 4) can be ray traced. Triangulate the model on export."
+            )
+
+        attributes = primitive.attributes
+        if getattr(attributes, "JOINTS_0", None) is not None:
+            raise NotImplementedError(
+                "Skinned meshes (JOINTS_0/WEIGHTS_0 attributes) are not "
+                "supported: skinning moves individual vertices, while the ray "
+                "tracer transforms each target rigidly."
+            )
+        if primitive.targets:
+            raise NotImplementedError(
+                "Morph targets are not supported: they deform the mesh, which "
+                "the ray tracer treats as rigid."
+            )
+
+        points = _read_accessor(gltf, blob, attributes.POSITION)
+        if primitive.indices is None:
+            cells = np.arange(len(points), dtype=np.int64).reshape(-1, 3)
+        else:
+            cells = _read_accessor(gltf, blob, primitive.indices)
+            cells = cells.astype(np.int64).reshape(-1, 3)
+
+        points_list.append(points)
+        cells_list.append(cells + offset)
+        offset += len(points)
+
+    if not points_list:
+        return np.zeros((0, 3)), np.zeros((0, 3), dtype=np.int64)
+
+    return np.concatenate(points_list, axis=0), np.concatenate(cells_list, axis=0)
+
+
+def _apply_affine(
+    points: NDArray, translation: NDArray, quat: NDArray, scale: NDArray
+) -> NDArray:
+    """
+    Apply a TRS transform to a point cloud
+
+    :param numpy.ndarray points: Points, shape ``[n, 3]``
+    :param numpy.ndarray translation: Translation, shape ``[3]``
+    :param numpy.ndarray quat: Rotation quaternion, shape ``[4]``
+    :param numpy.ndarray scale: Scale, shape ``[3]``
+
+    :return: The transformed points, shape ``[n, 3]``
+    :rtype: numpy.ndarray
+    """
+    if len(points) == 0:
+        return points
+    return _quat_rotate(quat, points * scale) + translation
+
+
+# =============================================================================
+# Model loading
+# =============================================================================
+
+
+def load_animated_model(  # pylint: disable=too-many-locals
+    filename: str,
+    *,
+    animation: Optional[Union[int, str]] = None,
+    unit: str = "m",
+    up_axis: str = "y",
+    merge_static: bool = True,
+) -> Dict[str, Any]:
+    """
+    Load an animated glTF 2.0 / GLB model and split it into rigid parts
+
+    Geometry is grouped by the nearest animated ancestor node, so each returned
+    part moves as one rigid body. Parts are expressed in their own node frame,
+    which is the frame their sampled pose applies to.
+
+    :param str filename: Path to a ``.gltf`` or ``.glb`` file
+    :param animation: Animation name or index to read. Default: the first one.
+    :param str unit: Unit the file is authored in (``'m'``, ``'cm'``, ``'mm'``).
+        Default: ``'m'``, which is what the glTF specification mandates.
+    :param str up_axis: Up axis of the file, ``'y'`` (glTF default) or ``'z'``.
+        Geometry and motion are rotated into RadarSimPy's Z-up frame.
+    :param bool merge_static: Merge all non-animated geometry into a single
+        part. Default: ``True``.
+
+    :return: Dictionary containing:
+
+        * **parts** (*list*): One entry per rigid part, each a dict with
+          ``name``, ``points``, ``cells``, ``node`` and ``animated``.
+        * **animation** (*str or None*): Name of the selected animation.
+        * **animations** (*list*): Names of every animation in the file.
+        * **duration** (*float*): Length of the selected animation in seconds.
+        * **start_time** (*float*): Time of its first keyframe in seconds.
+    :rtype: dict
+    :raises NotImplementedError: For skinning, morph targets, animated scale,
+        non-uniform scale on an animated node, or non-triangle primitives.
+    """
+    if unit not in UNIT_SCALE:
+        raise ValueError(
+            f"Invalid unit '{unit}'. Supported units: {list(UNIT_SCALE.keys())}"
+        )
+    if up_axis not in ("y", "z"):
+        raise ValueError(f"Invalid up_axis '{up_axis}'. Supported: 'y', 'z'.")
+
+    gltf_module = import_gltf_module()
+    gltf = gltf_module.GLTF2().load(filename)
+    if gltf is None:
+        raise RuntimeError(f"Failed to load glTF model '{filename}'.")
+
+    blob = _resolve_blob(gltf, gltf_module)
+    parent_of, roots = _build_hierarchy(gltf)
+    animation_index = _select_animation(gltf, animation)
+    tracks = _collect_tracks(gltf, blob, animation_index)
+    animated_nodes = set(tracks)
+
+    scale_divisor = UNIT_SCALE[unit]
+    rest_poses = {index: _node_rest_pose(gltf.nodes[index]) for index in parent_of}
+
+    _validate_animated_scale(gltf, parent_of, rest_poses, animated_nodes)
+
+    # Walk the tree, accumulating each mesh into the bucket of its nearest
+    # animated ancestor. ``local`` is the transform from that ancestor down to
+    # the current node, which is constant and can be baked into the vertices.
+    # ``cumulative`` is the scale from the root, tracked separately because an
+    # animated node's own scale still has to reach its vertices even though its
+    # rotation and translation come from the sampled pose instead.
+    buckets: Dict[Optional[int], List[Tuple[NDArray, NDArray]]] = {}
+    stack = [
+        (root, None, (np.zeros(3), _Q_IDENTITY.copy(), np.ones(3)), np.ones(3))
+        for root in reversed(roots)
+    ]
+    while stack:
+        index, owner, local, cumulative = stack.pop()
+        translation, quat, scale = rest_poses[index]
+        cumulative = cumulative * scale
+
+        if index in animated_nodes:
+            owner = index
+            local = (np.zeros(3), _Q_IDENTITY.copy(), cumulative.copy())
+        else:
+            local = _compose_affine(local, (translation, quat, scale))
+
+        node = gltf.nodes[index]
+        if node.mesh is not None:
+            points, cells = _node_geometry(gltf, blob, node)
+            if len(cells):
+                buckets.setdefault(owner, []).append(
+                    (_apply_affine(points, *local) / scale_divisor, cells)
+                )
+
+        for child in node.children or []:
+            stack.append((child, owner, local, cumulative))
+
+    parts = _assemble_parts(gltf, buckets, animated_nodes, merge_static)
+
+    start_time, end_time = _clip_time_range(tracks)
+    return {
+        "parts": parts,
+        "animation": (
+            gltf.animations[animation_index].name
+            if animation_index is not None
+            else None
+        ),
+        "animations": [clip.name for clip in gltf.animations],
+        "duration": end_time - start_time,
+        "start_time": start_time,
+        "_tracks": tracks,
+        "_parent_of": parent_of,
+        "_rest_poses": rest_poses,
+        "_scale_divisor": scale_divisor,
+        "_up_axis": up_axis,
+    }
+
+
+def _compose_affine(
+    outer: Tuple[NDArray, NDArray, NDArray], inner: Tuple[NDArray, NDArray, NDArray]
+) -> Tuple[NDArray, NDArray, NDArray]:
+    """
+    Compose two TRS transforms, outer applied after inner
+
+    :param tuple outer: ``(translation, quaternion, scale)`` of the parent
+    :param tuple inner: ``(translation, quaternion, scale)`` of the child
+
+    :return: The composed ``(translation, quaternion, scale)``
+    :rtype: tuple
+    """
+    out_t, out_q, out_s = outer
+    in_t, in_q, in_s = inner
+    return (
+        out_t + _quat_rotate(out_q, in_t * out_s),
+        _quat_multiply(out_q, in_q),
+        out_s * in_s,
+    )
+
+
+def _validate_animated_scale(
+    gltf: Any,
+    parent_of: Dict[int, Optional[int]],
+    rest_poses: Dict[int, Tuple[NDArray, NDArray, NDArray]],
+    animated_nodes: set,
+) -> None:
+    """
+    Reject non-uniform scale anywhere on an animated node's ancestor chain
+
+    A part's pose is emitted as a rotation plus a translation, so a non-uniform
+    scale above it cannot be represented and would silently distort the mesh.
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param dict parent_of: Node to parent map
+    :param dict rest_poses: Node to rest ``(translation, quaternion, scale)``
+    :param set animated_nodes: Indices of animated nodes
+
+    :raises NotImplementedError: If such a scale is found
+    """
+    for node_index in animated_nodes:
+        index: Optional[int] = node_index
+        while index is not None:
+            scale = rest_poses[index][2]
+            if not np.allclose(scale, scale[0], rtol=1e-6, atol=1e-9):
+                name = gltf.nodes[index].name or f"node {index}"
+                raise NotImplementedError(
+                    f"Node '{name}' has a non-uniform scale {tuple(scale)} on the "
+                    "transform chain of an animated node. Only uniform scale is "
+                    "supported there, because a part's pose is emitted as a "
+                    "rotation plus a translation. Apply the scale to the mesh on "
+                    "export."
+                )
+            index = parent_of[index]
+
+
+def _assemble_parts(
+    gltf: Any,
+    buckets: Dict[Optional[int], List[Tuple[NDArray, NDArray]]],
+    animated_nodes: set,
+    merge_static: bool,
+) -> List[Dict[str, Any]]:
+    """
+    Turn per-owner geometry buckets into part records
+
+    :param gltf: The loaded ``GLTF2`` object
+    :param dict buckets: ``{owner node or None: [(points, cells), ...]}``
+    :param set animated_nodes: Indices of animated nodes
+    :param bool merge_static: Merge every static mesh into one part
+
+    :return: Part records
+    :rtype: list
+    """
+    parts: List[Dict[str, Any]] = []
+
+    for owner in sorted(index for index in buckets if index is not None):
+        points, cells = _merge_geometry(buckets[owner])
+        parts.append(
+            {
+                "name": gltf.nodes[owner].name or f"node_{owner}",
+                "points": points,
+                "cells": cells,
+                "node": owner,
+                "animated": owner in animated_nodes,
+            }
+        )
+
+    static = buckets.get(None, [])
+    if static:
+        if merge_static:
+            points, cells = _merge_geometry(static)
+            parts.append(
+                {
+                    "name": "static",
+                    "points": points,
+                    "cells": cells,
+                    "node": None,
+                    "animated": False,
+                }
+            )
+        else:
+            for order, (points, cells) in enumerate(static):
+                parts.append(
+                    {
+                        "name": f"static_{order}",
+                        "points": points,
+                        "cells": cells,
+                        "node": None,
+                        "animated": False,
+                    }
+                )
+
+    return parts
+
+
+def _merge_geometry(chunks: List[Tuple[NDArray, NDArray]]) -> Tuple[NDArray, NDArray]:
+    """
+    Concatenate ``(points, cells)`` chunks, offsetting the face indices
+
+    :param list chunks: ``[(points, cells), ...]``
+
+    :return: ``(points, cells)``
+    :rtype: tuple
+    """
+    points_list, cells_list, offset = [], [], 0
+    for points, cells in chunks:
+        points_list.append(points)
+        cells_list.append(cells + offset)
+        offset += len(points)
+    return np.concatenate(points_list, axis=0), np.concatenate(cells_list, axis=0)
+
+
+# =============================================================================
+# Pose sampling
+# =============================================================================
+
+
+def _sample_node_pose(  # pylint: disable=too-many-locals
+    node_index: int,
+    model: Dict[str, Any],
+    anim_times: NDArray,
+    time_scale: float,
+) -> Tuple[NDArray, NDArray, NDArray, NDArray]:
+    """
+    World pose and velocity of one node, sampled at the given animation times
+
+    Composes the ancestor chain in ``(quaternion, translation)`` space and
+    propagates the exact rigid-body velocity recursions
+
+    .. math::
+
+        v_w &= v_p + \\omega_p \\times (R_p\\, s_p\\, t_l) + R_p\\, s_p\\, \\dot{t}_l \\\\
+        \\omega_w &= \\omega_p + R_w\\, \\omega_{body}
+
+    so linear and angular rates stay exact rather than being differenced off
+    the sample grid.
+
+    :param int node_index: Node to sample
+    :param dict model: Model from :func:`load_animated_model`
+    :param numpy.ndarray anim_times: Animation times (s), shape ``[k]``
+    :param float time_scale: ``d(animation time) / d(simulation time)``
+
+    :return: ``(translation[k,3], quaternion[k,4], velocity[k,3],
+        angular_velocity[k,3])`` in the file's own frame and units
+    :rtype: tuple
+    """
+    chain: List[int] = []
+    index: Optional[int] = node_index
+    while index is not None:
+        chain.append(index)
+        index = model["_parent_of"][index]
+    chain.reverse()
+
+    n_times = len(anim_times)
+    world_t = np.zeros((n_times, 3))
+    world_q = np.tile(_Q_IDENTITY, (n_times, 1))
+    world_v = np.zeros((n_times, 3))
+    world_w = np.zeros((n_times, 3))
+    world_scale = 1.0
+
+    for index in chain:
+        rest_t, rest_q, rest_s = model["_rest_poses"][index]
+        node_tracks = model["_tracks"].get(index, {})
+
+        if "translation" in node_tracks:
+            local_t, local_t_dot = node_tracks["translation"].evaluate(anim_times)
+            local_t_dot = local_t_dot * time_scale
+        else:
+            local_t = np.broadcast_to(rest_t, (n_times, 3))
+            local_t_dot = np.zeros((n_times, 3))
+
+        if "rotation" in node_tracks:
+            local_q, local_q_dot = node_tracks["rotation"].evaluate(anim_times)
+            local_q = _quat_normalize(local_q)
+            rate_body = _angular_velocity(local_q, local_q_dot) * time_scale
+        else:
+            local_q = np.broadcast_to(rest_q, (n_times, 4))
+            rate_body = np.zeros((n_times, 3))
+
+        offset = _quat_rotate(world_q, local_t * world_scale)
+        world_v = (
+            world_v
+            + np.cross(world_w, offset)
+            + _quat_rotate(world_q, local_t_dot * world_scale)
+        )
+        world_t = world_t + offset
+        world_q = _quat_multiply(world_q, local_q)
+        world_w = world_w + _quat_rotate(world_q, rate_body)
+        world_scale = world_scale * float(rest_s[0])
+
+    return world_t, world_q, world_v, world_w
+
+
+def _to_zup(
+    translation: NDArray, quat: NDArray, velocity: NDArray, omega: NDArray
+) -> Tuple[NDArray, NDArray, NDArray, NDArray]:
+    """
+    Rotate a pose and its rates from glTF's Y-up frame into RadarSimPy's Z-up frame
+
+    A world point is ``C (R p + t) = (C R C^T)(C p) + C t``, so vectors are
+    simply rotated by ``C`` while the orientation takes the similarity
+    transform ``C R C^T`` — the part's own vertices are rotated by ``C``
+    separately in :func:`_orient_points`.
+
+    :param numpy.ndarray translation: Translation, shape ``[k, 3]``
+    :param numpy.ndarray quat: Rotation, shape ``[k, 4]``
+    :param numpy.ndarray velocity: Linear velocity, shape ``[k, 3]``
+    :param numpy.ndarray omega: Angular velocity, shape ``[k, 3]``
+
+    :return: The same quantities in the Z-up frame
+    :rtype: tuple
+    """
+    return (
+        _quat_rotate(_Q_YUP_TO_ZUP, translation),
+        _quat_multiply(
+            _quat_multiply(_Q_YUP_TO_ZUP, quat), _quat_conjugate(_Q_YUP_TO_ZUP)
+        ),
+        _quat_rotate(_Q_YUP_TO_ZUP, velocity),
+        _quat_rotate(_Q_YUP_TO_ZUP, omega),
+    )
+
+
+def _map_time(
+    timestamp: NDArray,
+    model: Dict[str, Any],
+    time_offset: float,
+    time_scale: float,
+    loop: bool,
+) -> NDArray:
+    """
+    Map simulation time to animation time, wrapping or clamping to the clip
+
+    :param numpy.ndarray timestamp: Simulation timestamps (s)
+    :param dict model: Model from :func:`load_animated_model`
+    :param float time_offset: Animation time at simulation time zero (s)
+    :param float time_scale: Playback rate
+    :param bool loop: Wrap past the end of the clip instead of holding the last pose
+
+    :return: Animation times (s), same shape as ``timestamp``
+    :rtype: numpy.ndarray
+    """
+    anim_times = np.asarray(timestamp, dtype=np.float64) * time_scale + time_offset
+    duration = model["duration"]
+    if loop and duration > 0.0:
+        anim_times = model["start_time"] + np.mod(
+            anim_times - model["start_time"], duration
+        )
+    return anim_times
+
+
+# =============================================================================
+# Target generation
+# =============================================================================
+
+
+def load_animated_targets(  # pylint: disable=too-many-arguments, too-many-locals
+    filename: Union[str, Dict[str, Any]],
+    radar: Any = None,
+    *,
+    at_time: Optional[float] = None,
+    animation: Optional[Union[int, str]] = None,
+    time_offset: float = 0.0,
+    time_scale: float = 1.0,
+    loop: bool = True,
+    location: Sequence[float] = (0, 0, 0),
+    speed: Sequence[float] = (0, 0, 0),
+    rotation: Sequence[float] = (0, 0, 0),
+    rotation_rate: Sequence[float] = (0, 0, 0),
+    unit: str = "m",
+    up_axis: str = "y",
+    merge_static: bool = True,
+    **target_kwargs: Any,
+) -> List[Dict[str, Any]]:
+    """
+    Build RadarSimPy target dictionaries from an animated glTF 2.0 / GLB model
+
+    Each animated node of the model becomes one target whose ``location``,
+    ``speed``, ``rotation`` and ``rotation_rate`` are arrays sampled at
+    ``radar.time_prop["timestamp"]``, so the motion authored in the file drives
+    both the geometry and the Doppler. Non-animated geometry becomes a single
+    static target.
+
+    The returned list is passed straight to :func:`radarsimpy.sim_radar`:
+
+    >>> targets = load_animated_targets("turbine.glb", radar, location=(50, 0, 0))
+    >>> data = sim_radar(radar, targets)
+
+    Only rigid node animation is supported. Skinned meshes, morph targets and
+    animated scale raise :class:`NotImplementedError`, because the ray tracer
+    transforms each target rigidly and cannot move individual vertices.
+
+    .. note::
+        Every animated part allocates twelve ``float32`` arrays the size of
+        ``radar.time_prop["timestamp"]``. Models with many independently moving
+        parts, simulated over long time records, use a correspondingly large
+        amount of memory. Merge parts that do not move independently to reduce it.
+
+    :param filename: Path to a ``.gltf``/``.glb`` file, or a model already
+        returned by :func:`load_animated_model`.
+    :param radar: :class:`radarsimpy.Radar` whose timestamps the animation is
+        sampled at. Required unless ``at_time`` is given.
+    :param at_time: Sample a single instant instead, returning static targets.
+        Use this for :func:`radarsimpy.sim_rcs` and :func:`radarsimpy.sim_lidar`,
+        which do not accept time-varying motion.
+    :param animation: Animation name or index. Default: the first one.
+    :param float time_offset: Animation time at simulation time zero (s).
+    :param float time_scale: Playback rate; ``2.0`` plays twice as fast.
+    :param bool loop: Wrap the animation when the simulation outlasts the clip.
+        When ``False`` the first and last poses are held. Default: ``True``.
+    :param location: Position of the whole model in the global frame [x, y, z] (m).
+    :param speed: Velocity of the whole model [vx, vy, vz] (m/s).
+    :param rotation: Orientation of the whole model [yaw, pitch, roll] (deg).
+    :param rotation_rate: Rotation rate of the whole model
+        [yaw rate, pitch rate, roll rate] (deg/s).
+    :param str unit: Unit the file is authored in. Default: ``'m'``.
+    :param str up_axis: Up axis of the file, ``'y'`` or ``'z'``. Default: ``'y'``.
+    :param bool merge_static: Merge all non-animated geometry into one target.
+    :param target_kwargs: Extra keys copied into every target dictionary, such
+        as ``permittivity``, ``permeability``, ``skip_diffusion``, ``density``
+        and ``environment``.
+
+    :return: Target dictionaries ready for :func:`radarsimpy.sim_radar`
+    :rtype: list
+    :raises ValueError: If neither ``radar`` nor ``at_time`` is provided
+    """
+    if isinstance(filename, dict):
+        model = filename
+    else:
+        model = load_animated_model(
+            filename,
+            animation=animation,
+            unit=unit,
+            up_axis=up_axis,
+            merge_static=merge_static,
+        )
+
+    if radar is not None:
+        timestamp = np.asarray(radar.time_prop["timestamp"], dtype=np.float64)
+        if timestamp.ndim != 3:
+            raise ValueError(
+                "radar.time_prop['timestamp'] must be 3-D "
+                f"[channels, pulses, samples]; got shape {timestamp.shape}."
+            )
+    elif at_time is not None:
+        timestamp = np.asarray([[[float(at_time)]]], dtype=np.float64)
+    else:
+        raise ValueError(
+            "Provide 'radar' to sample the animation at the simulation "
+            "timestamps, or 'at_time' to take a single static snapshot."
+        )
+
+    static_only = radar is None
+    ts_shape = timestamp.shape
+    anim_times = _map_time(timestamp, model, time_offset, time_scale, loop).reshape(-1)
+    flat_time = timestamp.reshape(-1)
+
+    outer = _outer_transform(location, speed, rotation, rotation_rate, flat_time)
+
+    targets: List[Dict[str, Any]] = []
+    for part in model["parts"]:
+        if len(part["cells"]) == 0:
+            continue
+
+        points = _orient_points(part["points"], model["_up_axis"])
+
+        if part["animated"]:
+            part_t, part_q, part_v, part_w = _sample_node_pose(
+                part["node"], model, anim_times, time_scale
+            )
+            # ``_sample_node_pose`` works in the file's own units and frame.
+            part_t = part_t / model["_scale_divisor"]
+            part_v = part_v / model["_scale_divisor"]
+            if model["_up_axis"] == "y":
+                part_t, part_q, part_v, part_w = _to_zup(part_t, part_q, part_v, part_w)
+        else:
+            part_t = np.zeros((len(anim_times), 3))
+            part_q = np.tile(_Q_IDENTITY, (len(anim_times), 1))
+            part_v = np.zeros((len(anim_times), 3))
+            part_w = np.zeros((len(anim_times), 3))
+
+        targets.append(
+            _build_target(
+                points=points,
+                cells=part["cells"],
+                part_pose=(part_t, part_q, part_v, part_w),
+                outer=outer,
+                ts_shape=ts_shape,
+                static_only=static_only,
+                target_kwargs=target_kwargs,
+            )
+        )
+
+    return targets
+
+
+def _orient_points(points: NDArray, up_axis: str) -> NDArray:
+    """
+    Rotate part geometry into RadarSimPy's Z-up frame
+
+    :param numpy.ndarray points: Points, shape ``[n, 3]``
+    :param str up_axis: Up axis of the source file
+
+    :return: Points in the Z-up frame, shape ``[n, 3]``
+    :rtype: numpy.ndarray
+    """
+    if up_axis == "z" or len(points) == 0:
+        return points
+    return _quat_rotate(_Q_YUP_TO_ZUP, points)
+
+
+def _outer_transform(
+    location: Sequence[float],
+    speed: Sequence[float],
+    rotation: Sequence[float],
+    rotation_rate: Sequence[float],
+    flat_time: NDArray,
+) -> Tuple[NDArray, NDArray, NDArray, NDArray]:
+    """
+    Sample the user's placement transform for the whole model
+
+    The angular velocity is taken as ``[roll_rate, pitch_rate, yaw_rate]`` in
+    the world frame, matching how ``CalculateSpeed`` in RadarSimCpp interprets
+    a constant ``rotation_rate``. That reading is exact for rotation about a
+    single axis, which is the case this placement argument is meant for.
+
+    :param location: Model position [x, y, z] (m)
+    :param speed: Model velocity [vx, vy, vz] (m/s)
+    :param rotation: Model orientation [yaw, pitch, roll] (deg)
+    :param rotation_rate: Model rotation rate [yaw, pitch, roll] rate (deg/s)
+    :param numpy.ndarray flat_time: Simulation timestamps, shape ``[k]``
+
+    :return: ``(translation[k,3], quaternion[k,4], velocity[k,3],
+        angular_velocity[k,3])``
+    :rtype: tuple
+    """
+    location = np.asarray(location, dtype=np.float64).reshape(3)
+    speed = np.asarray(speed, dtype=np.float64).reshape(3)
+    rotation = np.radians(np.asarray(rotation, dtype=np.float64).reshape(3))
+    rotation_rate = np.radians(np.asarray(rotation_rate, dtype=np.float64).reshape(3))
+
+    n_times = len(flat_time)
+    translation = location + np.outer(flat_time, speed)
+    velocity = np.broadcast_to(speed, (n_times, 3))
+
+    if np.any(rotation_rate):
+        angles = rotation + np.outer(flat_time, rotation_rate)
+        quat = np.stack([_rsx_euler_to_quat(angle) for angle in angles])
+    else:
+        quat = np.tile(_rsx_euler_to_quat(rotation), (n_times, 1))
+
+    omega = np.broadcast_to(
+        np.array([rotation_rate[2], rotation_rate[1], rotation_rate[0]]), (n_times, 3)
+    )
+    return translation, quat, velocity, omega
+
+
+def _build_target(  # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals
+    points: NDArray,
+    cells: NDArray,
+    part_pose: Tuple[NDArray, NDArray, NDArray, NDArray],
+    outer: Tuple[NDArray, NDArray, NDArray, NDArray],
+    ts_shape: Tuple[int, int, int],
+    static_only: bool,
+    target_kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Compose a part's pose with the model placement and emit a target dictionary
+
+    :param numpy.ndarray points: Part geometry, shape ``[n, 3]``
+    :param numpy.ndarray cells: Part faces, shape ``[m, 3]``
+    :param tuple part_pose: ``(translation, quaternion, velocity, omega)`` of the part
+    :param tuple outer: The same four quantities for the model placement
+    :param tuple ts_shape: Shape of ``radar.time_prop["timestamp"]``
+    :param bool static_only: Emit scalar motion instead of per-timestamp arrays
+    :param dict target_kwargs: Extra target keys to copy through
+
+    :return: A RadarSimPy target dictionary
+    :rtype: dict
+    """
+    part_t, part_q, part_v, part_w = part_pose
+    outer_t, outer_q, outer_v, outer_w = outer
+
+    offset = _quat_rotate(outer_q, part_t)
+    world_t = outer_t + offset
+    world_q = _quat_multiply(outer_q, part_q)
+    world_v = outer_v + np.cross(outer_w, offset) + _quat_rotate(outer_q, part_v)
+    world_w = outer_w + _quat_rotate(outer_q, part_w)
+
+    euler = np.degrees(_quat_to_rsx_euler(world_q))
+    rates = np.degrees(np.stack((world_w[:, 2], world_w[:, 1], world_w[:, 0]), axis=-1))
+
+    target: Dict[str, Any] = {
+        "model": {
+            "points": np.ascontiguousarray(points, dtype=np.float64),
+            "cells": np.ascontiguousarray(cells, dtype=np.int32),
+        },
+        "unit": "m",
+        "origin": (0.0, 0.0, 0.0),
+    }
+
+    if static_only:
+        target["location"] = tuple(world_t[0])
+        target["speed"] = tuple(world_v[0])
+        target["rotation"] = tuple(euler[0])
+        target["rotation_rate"] = tuple(rates[0])
+    else:
+        # ``MoveIndex`` advances the mesh by ``rotation[i] - rotation[i-1]``, and
+        # RadarSimCpp turns that difference into Rz(dyaw) Ry(-dpitch) Rx(droll).
+        # Each of those factors is 360-degree periodic, so a branch cut in the
+        # wrapped angles yields exactly the same rotation and the angles are
+        # deliberately left wrapped: accumulating unwrapped turns would grow
+        # without bound and lose float32 precision over a long time record.
+        target["location"] = _split_axes(world_t, ts_shape)
+        target["speed"] = _split_axes(world_v, ts_shape)
+        target["rotation"] = _split_axes(euler, ts_shape)
+        target["rotation_rate"] = _split_axes(rates, ts_shape)
+
+    target.update(target_kwargs)
+    return target
+
+
+def _split_axes(values: NDArray, ts_shape: Tuple[int, int, int]) -> Tuple[NDArray, ...]:
+    """
+    Split an ``[k, 3]`` array into three timestamp-shaped ``float32`` arrays
+
+    The time-varying kinematics path in ``cp_radarsimc`` binds each axis to a
+    C-contiguous ``float32[:, :, :]`` memoryview, so both the shape and the
+    dtype have to match ``radar.time_prop["timestamp"]``.
+
+    :param numpy.ndarray values: Values, shape ``[k, 3]``
+    :param tuple ts_shape: Shape of ``radar.time_prop["timestamp"]``
+
+    :return: One array per axis, each shaped ``ts_shape``
+    :rtype: tuple
+    """
+    return tuple(
+        np.ascontiguousarray(values[:, axis].reshape(ts_shape), dtype=np.float32)
+        for axis in range(3)
+    )

--- a/src/radarsimpy/mesh_kit.py
+++ b/src/radarsimpy/mesh_kit.py
@@ -70,7 +70,7 @@ def import_mesh_module() -> object:
     """
     Import the first available mesh processing module from a predefined list
 
-    Tries to import modules in this order: pyvista, pymeshlab, trimesh, meshio
+    Tries to import modules in this order: trimesh, pyvista, pymeshlab, meshio
 
     :return: The mesh processing module object
     :rtype: object
@@ -99,11 +99,17 @@ def import_mesh_module() -> object:
     )
 
 
-def load_mesh(mesh_file_name: str, scale: float, mesh_module: object) -> dict:
+def load_mesh(
+    mesh_file_name: Union[str, Dict[str, Any]], scale: float, mesh_module: object
+) -> dict:
     """
-    Load a 3D mesh file using the specified module
+    Load a 3D mesh from a file, or pass an in-memory mesh straight through
 
-    :param str mesh_file_name: Path to the mesh file
+    :param mesh_file_name: Path to the mesh file, or a dictionary holding the
+        geometry directly as ``{"points": [N, 3], "cells": [M, 3]}``. The
+        in-memory form lets callers supply generated geometry, and is how
+        :mod:`radarsimpy.animation_kit` hands over the parts it extracts from
+        an animated model.
     :param float scale: Scale factor to apply to the mesh vertices
     :param object mesh_module: The mesh processing module object
 
@@ -112,6 +118,12 @@ def load_mesh(mesh_file_name: str, scale: float, mesh_module: object) -> dict:
         - points (numpy.ndarray): Array of vertex coordinates
         - cells (numpy.ndarray): Array of face indices
     """
+    if isinstance(mesh_file_name, dict):
+        return {
+            "points": np.asarray(mesh_file_name["points"], dtype=float) / scale,
+            "cells": np.asarray(mesh_file_name["cells"]),
+        }
+
     if mesh_module.__name__ == "pyvista":
         mesh_data = mesh_module.read(mesh_file_name)
         points = np.array(mesh_data.points) / scale

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ Provides:
 * ``models_dir`` / ``model_path`` for referring to bundled 3D models.
 * ``mesh_module`` plus the ``mesh`` marker, which skip ray-tracing tests when
   no optional mesh-processing library is installed.
+* ``gltf_module`` plus the ``gltf`` marker, which do the same for the
+  optional glTF library used by ``radarsimpy.animation_kit``.
 * ``make_transmitter`` / ``make_receiver`` / ``make_radar`` factories for the
   small radar configurations that many tests need.
 
@@ -40,6 +42,9 @@ from radarsimpy.mesh_kit import check_module_installed
 #: Mesh libraries ``radarsimpy.mesh_kit.import_mesh_module`` knows how to use.
 MESH_MODULES = ("trimesh", "pyvista", "pymeshlab", "meshio")
 
+#: Library ``radarsimpy.animation_kit.import_gltf_module`` needs.
+GLTF_MODULE = "pygltflib"
+
 #: Repository root, i.e. the directory holding ``models/``.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -58,17 +63,25 @@ def _any_mesh_module_installed():
 
 
 def pytest_collection_modifyitems(config, items):  # pylint: disable=unused-argument
-    """Skip ``mesh``-marked tests when no mesh-processing library is available."""
-    if _any_mesh_module_installed() is not None:
-        return
+    """Skip marked tests whose optional library is not installed."""
+    skip_mesh = None
+    if _any_mesh_module_installed() is None:
+        skip_mesh = pytest.mark.skip(
+            reason="no mesh-processing library installed "
+            f"(install one of: {', '.join(MESH_MODULES)})"
+        )
 
-    skip_mesh = pytest.mark.skip(
-        reason="no mesh-processing library installed "
-        f"(install one of: {', '.join(MESH_MODULES)})"
-    )
+    skip_gltf = None
+    if not check_module_installed(GLTF_MODULE):
+        skip_gltf = pytest.mark.skip(
+            reason=f"{GLTF_MODULE} is not installed (pip install {GLTF_MODULE})"
+        )
+
     for item in items:
-        if "mesh" in item.keywords:
+        if skip_mesh is not None and "mesh" in item.keywords:
             item.add_marker(skip_mesh)
+        if skip_gltf is not None and "gltf" in item.keywords:
+            item.add_marker(skip_gltf)
 
 
 # =============================================================================
@@ -130,6 +143,12 @@ def mesh_module():
     if name is None:
         pytest.skip(f"no mesh-processing library installed ({', '.join(MESH_MODULES)})")
     return pytest.importorskip(name)
+
+
+@pytest.fixture(scope="session")
+def gltf_module():
+    """The glTF module used by ``animation_kit``, skipping the test if missing."""
+    return pytest.importorskip(GLTF_MODULE)
 
 
 # =============================================================================

--- a/tests/test_module_animation_kit.py
+++ b/tests/test_module_animation_kit.py
@@ -1,0 +1,1038 @@
+"""
+Tests for ``radarsimpy.animation_kit``
+
+Covers glTF parsing (accessors, scene graph, keyframe samplers), the mapping
+from animated nodes to RadarSimPy target dictionaries, the Y-up to Z-up frame
+conversion, and the unsupported-input errors. The end-to-end cases drive the
+real C++ ``Target`` transform through ``mesh_kit.get_target_mesh`` and compare
+``sim_radar`` output against hand-written constant-motion targets.
+
+Fixture models are built in ``tmp_path`` with ``pygltflib`` rather than being
+committed as binary assets.
+
+---
+
+- Copyright (C) 2018 - PRESENT  radarsimx.com
+- E-mail: info@radarsimx.com
+- Website: https://radarsimx.com
+
+::
+
+    ██████╗  █████╗ ██████╗  █████╗ ██████╗ ███████╗██╗███╗   ███╗██╗  ██╗
+    ██╔══██╗██╔══██╗██╔══██╗██╔══██╗██╔══██╗██╔════╝██║████╗ ████║╚██╗██╔╝
+    ██████╔╝███████║██║  ██║███████║██████╔╝███████╗██║██╔████╔██║ ╚███╔╝
+    ██╔══██╗██╔══██║██║  ██║██╔══██║██╔══██╗╚════██║██║██║╚██╔╝██║ ██╔██╗
+    ██║  ██║██║  ██║██████╔╝██║  ██║██║  ██║███████║██║██║ ╚═╝ ██║██╔╝ ██╗
+    ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═╝╚═╝     ╚═╝╚═╝  ╚═╝
+
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from radarsimpy import animation_kit, mesh_kit
+
+pytestmark = pytest.mark.gltf
+
+
+# =============================================================================
+# glTF fixture construction
+# =============================================================================
+
+
+def build_glb(path, nodes, channels=None, animation_name="clip"):
+    """
+    Write a minimal binary glTF built from plain numpy arrays.
+
+    ``nodes`` entries accept ``name``, ``points``, ``cells``, ``children``,
+    ``translation``, ``rotation`` (xyzw) and ``scale``. ``channels`` entries
+    accept ``node``, ``path``, ``times``, ``values`` and ``interpolation``.
+    """
+    import pygltflib as pg
+
+    blob = bytearray()
+    views, accessors = [], []
+
+    def add(array, component_type, acc_type, target=None):
+        arr = np.ascontiguousarray(array)
+        data = arr.tobytes()
+        offset = len(blob)
+        blob.extend(data)
+        while len(blob) % 4:
+            blob.append(0)
+        views.append(
+            pg.BufferView(
+                buffer=0, byteOffset=offset, byteLength=len(data), target=target
+            )
+        )
+        accessor = pg.Accessor(
+            bufferView=len(views) - 1,
+            byteOffset=0,
+            componentType=component_type,
+            count=arr.shape[0],
+            type=acc_type,
+        )
+        if component_type == pg.FLOAT:
+            flat = arr.reshape(arr.shape[0], -1)
+            accessor.max = flat.max(axis=0).tolist()
+            accessor.min = flat.min(axis=0).tolist()
+        accessors.append(accessor)
+        return len(accessors) - 1
+
+    meshes, gltf_nodes = [], []
+    for spec in nodes:
+        mesh_index = None
+        if spec.get("points") is not None:
+            position = add(
+                np.asarray(spec["points"], np.float32),
+                pg.FLOAT,
+                pg.VEC3,
+                pg.ARRAY_BUFFER,
+            )
+            indices = add(
+                np.asarray(spec["cells"], np.uint32).reshape(-1),
+                pg.UNSIGNED_INT,
+                pg.SCALAR,
+                pg.ELEMENT_ARRAY_BUFFER,
+            )
+            primitive = pg.Primitive(
+                attributes=pg.Attributes(POSITION=position),
+                indices=indices,
+                mode=spec.get("mode", pg.TRIANGLES),
+            )
+            if spec.get("skinned"):
+                primitive.attributes.JOINTS_0 = position
+            meshes.append(pg.Mesh(primitives=[primitive]))
+            mesh_index = len(meshes) - 1
+        gltf_nodes.append(
+            pg.Node(
+                name=spec.get("name"),
+                mesh=mesh_index,
+                children=spec.get("children") or [],
+                translation=spec.get("translation"),
+                rotation=spec.get("rotation"),
+                scale=spec.get("scale"),
+            )
+        )
+
+    animations = []
+    if channels:
+        samplers, gltf_channels = [], []
+        for channel in channels:
+            time_acc = add(
+                np.asarray(channel["times"], np.float32).reshape(-1, 1),
+                pg.FLOAT,
+                pg.SCALAR,
+            )
+            values = np.asarray(channel["values"], np.float32)
+            acc_type = {1: pg.SCALAR, 3: pg.VEC3, 4: pg.VEC4}[values.shape[-1]]
+            value_acc = add(values, pg.FLOAT, acc_type)
+            samplers.append(
+                pg.AnimationSampler(
+                    input=time_acc,
+                    output=value_acc,
+                    interpolation=channel.get("interpolation", "LINEAR"),
+                )
+            )
+            gltf_channels.append(
+                pg.AnimationChannel(
+                    sampler=len(samplers) - 1,
+                    target=pg.AnimationChannelTarget(
+                        node=channel["node"], path=channel["path"]
+                    ),
+                )
+            )
+        animations.append(
+            pg.Animation(name=animation_name, samplers=samplers, channels=gltf_channels)
+        )
+
+    children = {c for spec in nodes for c in (spec.get("children") or [])}
+    roots = [i for i in range(len(nodes)) if i not in children]
+
+    gltf = pg.GLTF2(
+        asset=pg.Asset(version="2.0"),
+        scene=0,
+        scenes=[pg.Scene(nodes=roots)],
+        nodes=gltf_nodes,
+        meshes=meshes,
+        accessors=accessors,
+        bufferViews=views,
+        buffers=[pg.Buffer(byteLength=len(blob))],
+        animations=animations,
+    )
+    gltf.set_binary_blob(bytes(blob))
+    gltf.save_binary(str(path))
+    return str(path)
+
+
+def horizontal_quad(size=1.0):
+    """A square in the glTF X-Z plane, i.e. horizontal under glTF's Y-up frame."""
+    half = size / 2.0
+    points = np.array(
+        [[-half, 0, -half], [half, 0, -half], [half, 0, half], [-half, 0, half]],
+        np.float32,
+    )
+    return points, np.array([[0, 1, 2], [0, 2, 3]], np.uint32)
+
+
+def vertical_quad(size=1.0):
+    """A square in the glTF Y-Z plane, which becomes the Y-Z plane in RadarSimPy."""
+    half = size / 2.0
+    points = np.array(
+        [[0, -half, -half], [0, half, -half], [0, half, half], [0, -half, half]],
+        np.float32,
+    )
+    return points, np.array([[0, 1, 2], [0, 2, 3]], np.uint32)
+
+
+def spin_keys(revs_per_second, duration, steps=64):
+    """LINEAR quaternion keyframes spinning about the glTF +Y axis."""
+    times = np.linspace(0.0, duration, steps + 1)
+    angles = 2 * np.pi * revs_per_second * times
+    zeros = np.zeros_like(angles)
+    quats = np.stack((zeros, np.sin(angles / 2), zeros, np.cos(angles / 2)), axis=-1)
+    return times, quats
+
+
+class FakeRadar:
+    """Minimal stand-in exposing only the timestamp ``animation_kit`` reads."""
+
+    def __init__(self, timestamp):
+        self.time_prop = {"timestamp": np.asarray(timestamp, dtype=np.float64)}
+
+
+@pytest.fixture
+def spinning_model(tmp_path):
+    """A single node spinning once per second about the glTF up axis."""
+    points, cells = horizontal_quad(2.0)
+    times, quats = spin_keys(1.0, 1.0)
+    return build_glb(
+        tmp_path / "spin.glb",
+        nodes=[{"name": "rotor", "points": points, "cells": cells}],
+        channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+    )
+
+
+@pytest.fixture
+def rising_model(tmp_path):
+    """A single node translating 10 m along the glTF up axis over one second."""
+    points, cells = horizontal_quad(2.0)
+    return build_glb(
+        tmp_path / "rise.glb",
+        nodes=[{"name": "lift", "points": points, "cells": cells}],
+        channels=[
+            {
+                "node": 0,
+                "path": "translation",
+                "times": np.array([0.0, 1.0]),
+                "values": np.array([[0, 0, 0], [0, 10.0, 0]]),
+            }
+        ],
+    )
+
+
+# =============================================================================
+# Module discovery
+# =============================================================================
+
+
+class TestModuleDiscovery:
+    """``import_gltf_module``."""
+
+    def test_returns_pygltflib(self, gltf_module):
+        """The discovered module is the one the tests build fixtures with."""
+        assert animation_kit.import_gltf_module() is gltf_module
+
+    def test_missing_module_raises_with_install_hint(self, monkeypatch):
+        """A missing library produces an actionable ImportError."""
+        monkeypatch.setattr(
+            animation_kit, "check_module_installed", lambda _name: False
+        )
+
+        with pytest.raises(ImportError, match="pip install pygltflib"):
+            animation_kit.import_gltf_module()
+
+
+# =============================================================================
+# Model parsing
+# =============================================================================
+
+
+class TestLoadAnimatedModel:
+    """``load_animated_model``."""
+
+    def test_reports_clip_metadata(self, spinning_model):
+        """Animation name, list and duration come back with the parts."""
+        model = animation_kit.load_animated_model(spinning_model)
+
+        assert model["animation"] == "clip"
+        assert model["animations"] == ["clip"]
+        assert model["duration"] == pytest.approx(1.0)
+        assert model["start_time"] == pytest.approx(0.0)
+
+    def test_animated_node_becomes_a_part(self, spinning_model):
+        """The one animated node yields one part carrying the geometry."""
+        parts = animation_kit.load_animated_model(spinning_model)["parts"]
+
+        assert len(parts) == 1
+        assert parts[0]["name"] == "rotor"
+        assert parts[0]["animated"] is True
+        assert parts[0]["points"].shape == (4, 3)
+        assert parts[0]["cells"].shape == (2, 3)
+
+    def test_static_geometry_is_merged(self, tmp_path):
+        """Meshes with no animated ancestor collapse into a single static part."""
+        points, cells = horizontal_quad()
+        times, quats = spin_keys(1.0, 1.0)
+        path = build_glb(
+            tmp_path / "mixed.glb",
+            nodes=[
+                {"name": "spin", "points": points, "cells": cells},
+                {
+                    "name": "body_a",
+                    "points": points,
+                    "cells": cells,
+                    "translation": [5.0, 0, 0],
+                },
+                {
+                    "name": "body_b",
+                    "points": points,
+                    "cells": cells,
+                    "translation": [-5.0, 0, 0],
+                },
+            ],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        parts = animation_kit.load_animated_model(path)["parts"]
+
+        assert [(part["name"], part["animated"]) for part in parts] == [
+            ("spin", True),
+            ("static", False),
+        ]
+        assert len(parts[1]["cells"]) == 4
+
+    def test_static_geometry_can_stay_split(self, tmp_path):
+        """``merge_static=False`` keeps one part per static mesh."""
+        points, cells = horizontal_quad()
+        times, quats = spin_keys(1.0, 1.0)
+        path = build_glb(
+            tmp_path / "mixed.glb",
+            nodes=[
+                {"name": "spin", "points": points, "cells": cells},
+                {"name": "body_a", "points": points, "cells": cells},
+                {"name": "body_b", "points": points, "cells": cells},
+            ],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        parts = animation_kit.load_animated_model(path, merge_static=False)["parts"]
+
+        assert [part["name"] for part in parts] == ["spin", "static_0", "static_1"]
+
+    def test_unit_scales_geometry_to_meters(self, spinning_model):
+        """A model authored in millimeters is converted to meters."""
+        model = animation_kit.load_animated_model(spinning_model, unit="mm")
+
+        assert model["parts"][0]["points"].max() == pytest.approx(1e-3)
+
+    def test_invalid_unit_rejected(self, spinning_model):
+        """An unknown unit is reported rather than silently ignored."""
+        with pytest.raises(ValueError, match="Invalid unit"):
+            animation_kit.load_animated_model(spinning_model, unit="furlong")
+
+    def test_invalid_up_axis_rejected(self, spinning_model):
+        """Only 'y' and 'z' up axes are accepted."""
+        with pytest.raises(ValueError, match="Invalid up_axis"):
+            animation_kit.load_animated_model(spinning_model, up_axis="x")
+
+    def test_unknown_animation_name_rejected(self, spinning_model):
+        """Selecting a missing animation lists what is available."""
+        with pytest.raises(ValueError, match="Available animations"):
+            animation_kit.load_animated_model(spinning_model, animation="walk")
+
+    def test_animation_index_out_of_range_rejected(self, spinning_model):
+        """An out-of-range animation index is reported."""
+        with pytest.raises(ValueError, match="out of range"):
+            animation_kit.load_animated_model(spinning_model, animation=7)
+
+
+# =============================================================================
+# Sampled motion
+# =============================================================================
+
+
+class TestRotationSampling:
+    """Rotation tracks turn into ``rotation`` / ``rotation_rate`` arrays."""
+
+    def test_yaw_follows_the_keyframes(self, spinning_model):
+        """A spin about the glTF up axis becomes pure yaw in RadarSimPy."""
+        radar = FakeRadar([[[0.0, 0.125, 0.25, 0.5]]])
+
+        target = animation_kit.load_animated_targets(spinning_model, radar)[0]
+
+        npt.assert_allclose(
+            target["rotation"][0].ravel(), [0.0, 45.0, 90.0, 180.0], atol=1e-3
+        )
+        npt.assert_allclose(target["rotation"][1].ravel(), 0.0, atol=1e-4)
+        npt.assert_allclose(target["rotation"][2].ravel(), 0.0, atol=1e-4)
+
+    def test_rotation_rate_matches_the_spin(self, spinning_model):
+        """One revolution per second is emitted as 360 deg/s of yaw rate."""
+        radar = FakeRadar([[[0.0, 0.125, 0.25, 0.5]]])
+
+        target = animation_kit.load_animated_targets(spinning_model, radar)[0]
+
+        npt.assert_allclose(target["rotation_rate"][0].ravel(), 360.0, rtol=1e-4)
+        npt.assert_allclose(target["rotation_rate"][1].ravel(), 0.0, atol=1e-4)
+        npt.assert_allclose(target["rotation_rate"][2].ravel(), 0.0, atol=1e-4)
+
+    def test_angles_stay_wrapped(self, spinning_model):
+        """
+        Angles are left in ``(-180, 180]``.
+
+        ``MoveIndex`` turns consecutive angles into ``Rz(dyaw) Ry(-dpitch)
+        Rx(droll)``, each factor 360-degree periodic, so wrapping is safe and
+        keeps the float32 arrays from growing without bound.
+        """
+        radar = FakeRadar([[np.linspace(0.0, 3.0, 64)]])
+
+        target = animation_kit.load_animated_targets(spinning_model, radar)[0]
+
+        assert np.abs(target["rotation"][0]).max() <= 180.0 + 1e-3
+
+    def test_gimbal_pole_warns(self, tmp_path):
+        """Reaching +/-90 deg of pitch warns that yaw and roll become ambiguous."""
+        points, cells = horizontal_quad()
+        angles = np.array([0.0, np.pi / 2])
+        zeros = np.zeros(2)
+        quats = np.stack(
+            (zeros, zeros, np.sin(angles / 2), np.cos(angles / 2)), axis=-1
+        )
+        path = build_glb(
+            tmp_path / "pole.glb",
+            nodes=[{"points": points, "cells": cells}],
+            channels=[
+                {
+                    "node": 0,
+                    "path": "rotation",
+                    "times": np.array([0.0, 1.0]),
+                    "values": quats,
+                }
+            ],
+        )
+        radar = FakeRadar([[[0.0, 1.0]]])
+
+        with pytest.warns(UserWarning, match="pitch"):
+            target = animation_kit.load_animated_targets(path, radar, loop=False)[0]
+
+        npt.assert_allclose(target["rotation"][1].ravel()[-1], 90.0, atol=1e-3)
+
+
+class TestTranslationSampling:
+    """Translation tracks turn into ``location`` / ``speed`` arrays."""
+
+    def test_up_axis_conversion(self, rising_model):
+        """Motion along glTF +Y lands on RadarSimPy +Z."""
+        radar = FakeRadar([[[0.0, 0.25, 0.5]]])
+
+        target = animation_kit.load_animated_targets(rising_model, radar)[0]
+
+        npt.assert_allclose(target["location"][0].ravel(), 0.0, atol=1e-6)
+        npt.assert_allclose(target["location"][1].ravel(), 0.0, atol=1e-6)
+        npt.assert_allclose(target["location"][2].ravel(), [0.0, 2.5, 5.0], atol=1e-5)
+
+    def test_speed_is_the_analytic_derivative(self, rising_model):
+        """
+        Velocity comes from the sampler, not from differencing the grid.
+
+        ``radar.time_prop["timestamp"]`` restarts at every channel, so a
+        difference over the flattened array would spike at each boundary.
+        """
+        timestamp = np.stack([np.linspace(0.0, 0.4, 8).reshape(2, 4)] * 3, axis=0)
+        radar = FakeRadar(timestamp)
+
+        target = animation_kit.load_animated_targets(rising_model, radar)[0]
+
+        npt.assert_allclose(target["speed"][2], 10.0, rtol=1e-5)
+        npt.assert_allclose(target["speed"][0], 0.0, atol=1e-5)
+
+    def test_z_up_models_are_not_rotated(self, rising_model):
+        """``up_axis='z'`` leaves an already Z-up asset alone."""
+        radar = FakeRadar([[[0.5]]])
+
+        target = animation_kit.load_animated_targets(rising_model, radar, up_axis="z")[
+            0
+        ]
+
+        npt.assert_allclose(target["location"][1].ravel(), 5.0, atol=1e-5)
+        npt.assert_allclose(target["location"][2].ravel(), 0.0, atol=1e-6)
+
+
+class TestHierarchy:
+    """Ancestor transforms compose into the sampled world pose."""
+
+    def test_child_geometry_is_baked_into_the_animated_parent(self, tmp_path):
+        """A static child under an animated parent joins the parent's part."""
+        points, cells = horizontal_quad(0.2)
+        times, quats = spin_keys(1.0, 1.0)
+        path = build_glb(
+            tmp_path / "hier.glb",
+            nodes=[
+                {"name": "hub", "children": [1], "translation": [0, 0, -10.0]},
+                {
+                    "name": "blade",
+                    "points": points,
+                    "cells": cells,
+                    "translation": [3.0, 0, 0],
+                },
+            ],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+        radar = FakeRadar([[[0.0]]])
+
+        model = animation_kit.load_animated_model(path)
+        target = animation_kit.load_animated_targets(path, radar)[0]
+
+        assert [part["name"] for part in model["parts"]] == ["hub"]
+        # The hub sits 10 m along glTF -Z, which is +Y in RadarSimPy.
+        npt.assert_allclose(target["location"][1].ravel(), 10.0, atol=1e-5)
+        # The blade's 3 m offset is baked into the vertices, not the location.
+        npt.assert_allclose(
+            target["model"]["points"].mean(axis=0), [3.0, 0.0, 0.0], atol=1e-5
+        )
+
+    def test_uniform_parent_scale_reaches_the_vertices(self, tmp_path):
+        """A uniform scale above an animated node is folded into its geometry."""
+        points, cells = horizontal_quad(2.0)
+        times, quats = spin_keys(1.0, 1.0)
+        path = build_glb(
+            tmp_path / "scaled.glb",
+            nodes=[
+                {"name": "root", "children": [1], "scale": [3.0, 3.0, 3.0]},
+                {"name": "spin", "points": points, "cells": cells},
+            ],
+            channels=[{"node": 1, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        parts = animation_kit.load_animated_model(path)["parts"]
+
+        assert parts[0]["points"].max() == pytest.approx(3.0)
+
+
+class TestPlacement:
+    """The outer ``location`` / ``speed`` / ``rotation`` arguments."""
+
+    def test_location_offsets_every_part(self, rising_model):
+        """The model placement adds to each part's sampled position."""
+        radar = FakeRadar([[[0.5]]])
+
+        target = animation_kit.load_animated_targets(
+            rising_model, radar, location=(20.0, -3.0, 1.0)
+        )[0]
+
+        npt.assert_allclose(target["location"][0].ravel(), 20.0, atol=1e-5)
+        npt.assert_allclose(target["location"][1].ravel(), -3.0, atol=1e-5)
+        npt.assert_allclose(target["location"][2].ravel(), 6.0, atol=1e-5)
+
+    def test_speed_adds_to_the_sampled_velocity(self, rising_model):
+        """Model velocity and part velocity superpose."""
+        radar = FakeRadar([[[0.0, 0.5]]])
+
+        target = animation_kit.load_animated_targets(
+            rising_model, radar, speed=(4.0, 0.0, 1.0)
+        )[0]
+
+        npt.assert_allclose(target["speed"][0].ravel(), 4.0, atol=1e-5)
+        npt.assert_allclose(target["speed"][2].ravel(), 11.0, rtol=1e-5)
+        npt.assert_allclose(target["location"][0].ravel(), [0.0, 2.0], atol=1e-5)
+
+    def test_rotation_turns_the_whole_model(self, rising_model):
+        """A 90 deg model yaw rotates each part's motion into the new frame."""
+        radar = FakeRadar([[[0.5]]])
+
+        target = animation_kit.load_animated_targets(
+            rising_model, radar, rotation=(90.0, 0.0, 0.0)
+        )[0]
+
+        npt.assert_allclose(target["rotation"][0].ravel(), 90.0, atol=1e-3)
+        # Motion is along the model's up axis, which yaw leaves untouched.
+        npt.assert_allclose(target["location"][2].ravel(), 5.0, atol=1e-5)
+
+
+class TestTimeMapping:
+    """``loop``, ``time_offset`` and ``time_scale``."""
+
+    def test_looping_wraps_past_the_clip(self, rising_model):
+        """Simulation time beyond the clip restarts it."""
+        radar = FakeRadar([[[0.0, 0.5, 1.0, 1.5, 2.5]]])
+
+        target = animation_kit.load_animated_targets(rising_model, radar)[0]
+
+        npt.assert_allclose(
+            target["location"][2].ravel(), [0.0, 5.0, 0.0, 5.0, 5.0], atol=1e-4
+        )
+
+    def test_clamping_holds_the_last_pose(self, rising_model):
+        """``loop=False`` holds the final keyframe and zeroes the rate."""
+        radar = FakeRadar([[[0.0, 0.5, 1.5, 2.5]]])
+
+        target = animation_kit.load_animated_targets(rising_model, radar, loop=False)[0]
+
+        npt.assert_allclose(
+            target["location"][2].ravel(), [0.0, 5.0, 10.0, 10.0], atol=1e-4
+        )
+        npt.assert_allclose(target["speed"][2].ravel()[-2:], 0.0, atol=1e-5)
+
+    def test_time_scale_speeds_the_clip_up(self, rising_model):
+        """``time_scale=2`` doubles both the progress and the velocity."""
+        radar = FakeRadar([[[0.0, 0.25]]])
+
+        target = animation_kit.load_animated_targets(
+            rising_model, radar, time_scale=2.0, loop=False
+        )[0]
+
+        npt.assert_allclose(target["location"][2].ravel(), [0.0, 5.0], atol=1e-4)
+        npt.assert_allclose(target["speed"][2].ravel(), 20.0, rtol=1e-5)
+
+    def test_time_offset_shifts_the_start(self, rising_model):
+        """``time_offset`` picks the animation time at simulation time zero."""
+        radar = FakeRadar([[[0.0]]])
+
+        target = animation_kit.load_animated_targets(
+            rising_model, radar, time_offset=0.75
+        )[0]
+
+        npt.assert_allclose(target["location"][2].ravel(), 7.5, atol=1e-4)
+
+
+class TestInterpolationModes:
+    """``STEP``, ``LINEAR`` and ``CUBICSPLINE`` samplers."""
+
+    def test_step_holds_each_key(self, tmp_path):
+        """STEP jumps between keys and reports a zero rate."""
+        points, cells = horizontal_quad()
+        path = build_glb(
+            tmp_path / "step.glb",
+            nodes=[{"points": points, "cells": cells}],
+            channels=[
+                {
+                    "node": 0,
+                    "path": "translation",
+                    "times": np.array([0.0, 0.5, 1.0]),
+                    "values": np.array([[0, 0, 0], [0, 4.0, 0], [0, 0, 0]]),
+                    "interpolation": "STEP",
+                }
+            ],
+        )
+        radar = FakeRadar([[[0.0, 0.25, 0.5, 0.75]]])
+
+        target = animation_kit.load_animated_targets(path, radar, loop=False)[0]
+
+        npt.assert_allclose(
+            target["location"][2].ravel(), [0.0, 0.0, 4.0, 4.0], atol=1e-5
+        )
+        npt.assert_allclose(target["speed"][2].ravel(), 0.0, atol=1e-6)
+
+    def test_cubicspline_matches_the_hermite_basis(self, tmp_path):
+        """CUBICSPLINE values and rates follow the analytic Hermite curve."""
+        points, cells = horizontal_quad()
+        keys = np.zeros((3, 3, 3))
+        keys[:, 1, :] = np.array([[0, 0, 0], [0, 4.0, 0], [0, 0, 0]])
+        path = build_glb(
+            tmp_path / "cubic.glb",
+            nodes=[{"points": points, "cells": cells}],
+            channels=[
+                {
+                    "node": 0,
+                    "path": "translation",
+                    "times": np.array([0.0, 0.5, 1.0]),
+                    "values": keys.reshape(9, 3),
+                    "interpolation": "CUBICSPLINE",
+                }
+            ],
+        )
+        radar = FakeRadar([[[0.0, 0.25, 0.5, 0.75]]])
+
+        target = animation_kit.load_animated_targets(path, radar, loop=False)[0]
+
+        # Zero tangents make each segment a smoothstep: half the rise at the
+        # midpoint, and a peak rate of 1.5 * 4 / 0.5 there.
+        npt.assert_allclose(
+            target["location"][2].ravel(), [0.0, 2.0, 4.0, 2.0], atol=1e-4
+        )
+        npt.assert_allclose(
+            target["speed"][2].ravel(), [0.0, 12.0, 0.0, -12.0], atol=1e-3
+        )
+
+
+class TestStaticSnapshot:
+    """``at_time`` for the simulators that reject time-varying motion."""
+
+    def test_at_time_emits_scalar_motion(self, rising_model):
+        """A snapshot has plain tuples, which ``sim_rcs``/``sim_lidar`` accept."""
+        target = animation_kit.load_animated_targets(rising_model, at_time=0.5)[0]
+
+        assert isinstance(target["location"], tuple)
+        assert all(
+            np.isscalar(value) or np.ndim(value) == 0 for value in target["location"]
+        )
+        npt.assert_allclose(target["location"][2], 5.0, atol=1e-6)
+
+    def test_missing_radar_and_time_is_rejected(self, rising_model):
+        """Neither sampling mode selected is an error, not a silent default."""
+        with pytest.raises(ValueError, match="at_time"):
+            animation_kit.load_animated_targets(rising_model)
+
+    def test_non_3d_timestamp_is_rejected(self, rising_model):
+        """The C++ motion arrays are indexed as [channels, pulses, samples]."""
+        with pytest.raises(ValueError, match="3-D"):
+            animation_kit.load_animated_targets(rising_model, FakeRadar([0.0, 1.0]))
+
+
+class TestTargetDictShape:
+    """The emitted dictionaries match what ``cp_AddTarget`` expects."""
+
+    def test_only_recognised_keys_are_emitted(self, spinning_model):
+        """Unknown keys would make ``sim_radar`` warn, so none are produced."""
+        valid = {
+            "model",
+            "unit",
+            "origin",
+            "location",
+            "speed",
+            "rotation",
+            "rotation_rate",
+            "permittivity",
+            "permeability",
+            "skip_diffusion",
+            "density",
+            "environment",
+        }
+        radar = FakeRadar([[[0.0]]])
+
+        targets = animation_kit.load_animated_targets(
+            spinning_model, radar, permittivity="PEC", skip_diffusion=True
+        )
+
+        assert set(targets[0]) <= valid
+        assert targets[0]["permittivity"] == "PEC"
+        assert targets[0]["skip_diffusion"] is True
+
+    def test_motion_arrays_match_the_timestamp_shape_and_dtype(self, spinning_model):
+        """Each axis binds to a C-contiguous float32 [ch, pulses, samples] view."""
+        timestamp = np.linspace(0.0, 1e-3, 24).reshape(2, 3, 4)
+        radar = FakeRadar(timestamp)
+
+        target = animation_kit.load_animated_targets(spinning_model, radar)[0]
+
+        for key in ("location", "speed", "rotation", "rotation_rate"):
+            for axis in target[key]:
+                assert axis.shape == timestamp.shape
+                assert axis.dtype == np.float32
+                assert axis.flags["C_CONTIGUOUS"]
+
+    def test_model_is_handed_over_in_memory(self, spinning_model):
+        """Geometry travels as a dict, which ``mesh_kit.load_mesh`` accepts."""
+        radar = FakeRadar([[[0.0]]])
+
+        target = animation_kit.load_animated_targets(spinning_model, radar)[0]
+
+        assert set(target["model"]) == {"points", "cells"}
+        assert target["model"]["cells"].dtype == np.int32
+        assert target["unit"] == "m"
+        assert target["origin"] == (0.0, 0.0, 0.0)
+
+
+# =============================================================================
+# Unsupported inputs
+# =============================================================================
+
+
+class TestUnsupportedInputs:
+    """Deforming geometry has no rigid-target representation."""
+
+    def test_animated_scale(self, tmp_path):
+        """A scale channel deforms the mesh."""
+        points, cells = horizontal_quad()
+        path = build_glb(
+            tmp_path / "scale.glb",
+            nodes=[{"points": points, "cells": cells}],
+            channels=[
+                {
+                    "node": 0,
+                    "path": "scale",
+                    "times": np.array([0.0, 1.0]),
+                    "values": np.array([[1.0, 1, 1], [2.0, 2, 2]]),
+                }
+            ],
+        )
+
+        with pytest.raises(NotImplementedError, match="Animated scale"):
+            animation_kit.load_animated_model(path)
+
+    def test_non_uniform_scale_on_an_animated_chain(self, tmp_path):
+        """A non-uniform scale cannot be split into a rotation and translation."""
+        points, cells = horizontal_quad()
+        times, quats = spin_keys(1.0, 1.0)
+        path = build_glb(
+            tmp_path / "nonuniform.glb",
+            nodes=[
+                {
+                    "name": "squashed",
+                    "points": points,
+                    "cells": cells,
+                    "scale": [1.0, 2.0, 1.0],
+                }
+            ],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        with pytest.raises(NotImplementedError, match="non-uniform scale"):
+            animation_kit.load_animated_model(path)
+
+    def test_skinned_mesh(self, tmp_path):
+        """Skinning moves individual vertices."""
+        points, cells = horizontal_quad()
+        path = build_glb(
+            tmp_path / "skinned.glb",
+            nodes=[{"points": points, "cells": cells, "skinned": True}],
+        )
+
+        with pytest.raises(NotImplementedError, match="Skinned"):
+            animation_kit.load_animated_model(path)
+
+    def test_non_triangle_primitive(self, tmp_path):
+        """Only triangles can be ray traced."""
+        import pygltflib as pg
+
+        points, cells = horizontal_quad()
+        path = build_glb(
+            tmp_path / "lines.glb",
+            nodes=[{"points": points, "cells": cells, "mode": pg.LINES}],
+        )
+
+        with pytest.raises(NotImplementedError, match="primitive mode"):
+            animation_kit.load_animated_model(path)
+
+
+# =============================================================================
+# Accessor decoding
+# =============================================================================
+
+
+class TestAccessorDecoding:
+    """``_read_accessor`` handles the buffer layouts exporters produce."""
+
+    def test_interleaved_byte_stride(self, gltf_module):
+        """Attributes packed with a byteStride are de-interleaved correctly."""
+        expected = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], np.float32)
+        padding = np.array([[9.0], [9.0]], np.float32)
+        blob = np.hstack((expected, padding)).tobytes()
+
+        gltf = gltf_module.GLTF2(
+            accessors=[
+                gltf_module.Accessor(
+                    bufferView=0,
+                    byteOffset=0,
+                    componentType=gltf_module.FLOAT,
+                    count=2,
+                    type=gltf_module.VEC3,
+                )
+            ],
+            bufferViews=[
+                gltf_module.BufferView(
+                    buffer=0, byteOffset=0, byteLength=len(blob), byteStride=16
+                )
+            ],
+        )
+
+        values = animation_kit._read_accessor(gltf, blob, 0)
+
+        npt.assert_allclose(values, expected)
+
+    def test_missing_buffer_view_reads_as_zeros(self, gltf_module):
+        """The spec defines an absent bufferView as all-zero data."""
+        gltf = gltf_module.GLTF2(
+            accessors=[
+                gltf_module.Accessor(
+                    componentType=gltf_module.FLOAT,
+                    count=3,
+                    type=gltf_module.VEC3,
+                )
+            ]
+        )
+
+        values = animation_kit._read_accessor(gltf, b"", 0)
+
+        npt.assert_array_equal(values, np.zeros((3, 3)))
+
+
+# =============================================================================
+# End to end, through the compiled transform
+# =============================================================================
+
+
+@pytest.mark.mesh
+class TestAgainstTheCppTransform:
+    """The emitted motion drives the real ``Target::Move`` correctly."""
+
+    def test_orbiting_part_traces_the_expected_circle(self, tmp_path, make_radar):
+        """
+        A blade offset from a spinning hub orbits at the analytic angle.
+
+        This validates the yaw/pitch/roll convention against RadarSimCpp rather
+        than against the extraction formula that produced it.
+        """
+        radar = make_radar(tx_kwargs={"pulses": 4})
+        timestamp = radar.time_prop["timestamp"]
+
+        revs_per_second = 625.0
+        points, cells = horizontal_quad(0.2)
+        times, quats = spin_keys(revs_per_second, 0.01, steps=400)
+        path = build_glb(
+            tmp_path / "orbit.glb",
+            nodes=[
+                {"name": "hub", "children": [1]},
+                {
+                    "name": "blade",
+                    "points": points,
+                    "cells": cells,
+                    "translation": [3.0, 0, 0],
+                },
+            ],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        targets = animation_kit.load_animated_targets(path, radar)
+        query = timestamp[0, :, 0]
+        mesh = mesh_kit.get_target_mesh(targets, radar, timestamp=query)
+
+        centre = mesh["points"].mean(axis=1)
+        npt.assert_allclose(np.linalg.norm(centre[:, :2], axis=1), 3.0, rtol=1e-4)
+        npt.assert_allclose(centre[:, 2], 0.0, atol=1e-4)
+
+        angle = np.degrees(np.arctan2(centre[:, 1], centre[:, 0]))
+        expected = np.degrees(2 * np.pi * revs_per_second * query)
+        npt.assert_allclose(angle % 360.0, expected % 360.0, atol=1e-2)
+
+
+@pytest.mark.mesh
+@pytest.mark.slow
+class TestSimRadarEquivalence:
+    """
+    The glTF path reproduces the hand-written constant-motion path.
+
+    This is the check that the Doppler is right and not just the geometry:
+    RadarSimCpp derives hit-point velocity from ``speed`` and ``rotation_rate``,
+    which the sampler has to supply independently of ``location``.
+    """
+
+    @staticmethod
+    def _radar(make_radar):
+        return make_radar(
+            tx_kwargs={
+                "f": [24.0e9, 24.2e9],
+                "t": 40e-6,
+                "tx_power": 15,
+                "prp": 50e-6,
+                "pulses": 8,
+            },
+            rx_kwargs={"fs": 4e6},
+        )
+
+    @staticmethod
+    def _reference_plate(size=1.0):
+        """The RadarSimPy-frame twin of :func:`vertical_quad`."""
+        half = size / 2.0
+        points = np.array(
+            [[0, half, -half], [0, half, half], [0, -half, half], [0, -half, -half]],
+            float,
+        )
+        return points, np.array([[0, 1, 2], [0, 2, 3]], np.int32)
+
+    def test_rotation_matches_a_constant_rotation_rate(self, tmp_path, make_radar):
+        """A spinning glTF node equals a target with the same ``rotation_rate``."""
+        from radarsimpy.simulator import sim_radar
+
+        radar = self._radar(make_radar)
+        revs_per_second = 100.0
+        points, cells = vertical_quad(1.0)
+        times, quats = spin_keys(revs_per_second, 0.02, steps=2000)
+        path = build_glb(
+            tmp_path / "spin.glb",
+            nodes=[{"name": "plate", "points": points, "cells": cells}],
+            channels=[{"node": 0, "path": "rotation", "times": times, "values": quats}],
+        )
+
+        animated = animation_kit.load_animated_targets(
+            path, radar, location=(20, 0, 0), permittivity="PEC"
+        )
+        ref_points, ref_cells = self._reference_plate(1.0)
+        reference = [
+            {
+                "model": {"points": ref_points, "cells": ref_cells},
+                "origin": (0, 0, 0),
+                "location": (20, 0, 0),
+                "rotation": (0, 0, 0),
+                "rotation_rate": (revs_per_second * 360.0, 0, 0),
+                "permittivity": "PEC",
+            }
+        ]
+
+        from_gltf = sim_radar(radar, animated, density=1, level="sample", device="cpu")[
+            "baseband"
+        ]
+        from_dict = sim_radar(
+            radar, reference, density=1, level="sample", device="cpu"
+        )["baseband"]
+
+        peak = np.abs(from_dict).max()
+        assert peak > 0.0
+        assert np.abs(from_gltf - from_dict).max() / peak < 1e-3
+
+    def test_translation_matches_a_constant_speed(self, tmp_path, make_radar):
+        """A translating glTF node equals a target with the same ``speed``."""
+        from radarsimpy.simulator import sim_radar
+
+        radar = self._radar(make_radar)
+        points, cells = vertical_quad(1.0)
+        path = build_glb(
+            tmp_path / "move.glb",
+            nodes=[{"name": "plate", "points": points, "cells": cells}],
+            channels=[
+                {
+                    "node": 0,
+                    "path": "translation",
+                    "times": np.array([0.0, 1.0]),
+                    # glTF -Z is RadarSimPy +Y.
+                    "values": np.array([[0, 0, 0], [0, 0, -30.0]]),
+                }
+            ],
+        )
+
+        animated = animation_kit.load_animated_targets(
+            path, radar, location=(20, 0, 0), permittivity="PEC"
+        )
+        ref_points, ref_cells = self._reference_plate(1.0)
+        reference = [
+            {
+                "model": {"points": ref_points, "cells": ref_cells},
+                "origin": (0, 0, 0),
+                "location": (20, 0, 0),
+                "speed": (0, 30.0, 0),
+                "permittivity": "PEC",
+            }
+        ]
+
+        from_gltf = sim_radar(radar, animated, density=1, level="sample", device="cpu")[
+            "baseband"
+        ]
+        from_dict = sim_radar(
+            radar, reference, density=1, level="sample", device="cpu"
+        )["baseband"]
+
+        peak = np.abs(from_dict).max()
+        assert peak > 0.0
+        assert np.abs(from_gltf - from_dict).max() / peak < 1e-3

--- a/tests/test_module_mesh_kit.py
+++ b/tests/test_module_mesh_kit.py
@@ -2,7 +2,8 @@
 Tests for ``radarsimpy.mesh_kit``
 
 Covers module discovery (``check_module_installed``, ``safe_import``,
-``import_mesh_module``), the per-backend branches of ``load_mesh``,
+``import_mesh_module``), the inline-geometry and per-backend branches of
+``load_mesh``,
 ``merge_meshes`` and the input handling of ``get_target_mesh``.
 
 ---
@@ -108,6 +109,33 @@ class TestLoadMesh:
 
         npt.assert_allclose(scaled["points"], unscaled["points"] / 2.0)
         npt.assert_array_equal(scaled["cells"], unscaled["cells"])
+
+    def test_inline_geometry_bypasses_the_backend(self):
+        """
+        A dict of arrays is passed straight through, with no backend involved.
+
+        ``animation_kit`` hands the parts it extracts from an animated model
+        over this way, and callers can use it for generated geometry too.
+        """
+        points = np.array([[0.0, 0, 0], [2.0, 0, 0], [0, 2.0, 0]])
+        cells = np.array([[0, 1, 2]])
+        module = self._stub("no_such_backend")
+
+        mesh = mesh_kit.load_mesh({"points": points, "cells": cells}, 1.0, module)
+
+        npt.assert_allclose(mesh["points"], points)
+        npt.assert_array_equal(mesh["cells"], cells)
+
+    def test_inline_geometry_honours_scale(self):
+        """``scale`` divides inline vertices just as it does file vertices."""
+        points = np.array([[0.0, 0, 0], [2.0, 0, 0], [0, 2.0, 0]])
+        module = self._stub("no_such_backend")
+
+        mesh = mesh_kit.load_mesh(
+            {"points": points, "cells": [[0, 1, 2]]}, 1000.0, module
+        )
+
+        npt.assert_allclose(mesh["points"], points / 1000.0)
 
     def test_pyvista_branch(self):
         """The pyvista branch reads ``points`` and unpacks the ``faces`` array."""


### PR DESCRIPTION
Target motion could only be written by hand as constant speed and rotation_rate. Real assets already carry their motion: a drone with spinning rotors, a wind turbine, a car with turning wheels, or anything following a keyframed path. Re-deriving that per part is tedious, and a keyframed path is not expressible at all.

radarsimpy.animation_kit reads a keyframe-animated glTF 2.0 / GLB model and lowers it to ordinary target dictionaries. Each animated node becomes its own target whose location, speed, rotation and rotation_rate are sampled at radar.time_prop["timestamp"]; geometry is grouped into its nearest animated ancestor, and static meshes merge into one target.

    targets = load_animated_targets("turbine.glb", radar, location=(80, 0, 0))
    data = sim_radar(radar, targets)

No C++ or Cython change is needed. Target<T> already stores per-timestamp motion arrays, TargetsManager::AddTarget already takes them, and _expand_time_varying_kinematics already accepts arrays shaped like the radar timestamp, so the whole feature is a Python lowering pass and no extension rebuild is required.

Three points that are load-bearing:

Velocity is analytic, not differenced. RadarSimCpp derives Doppler from speed and rotation_rate, which the time-varying path consumes independently of location, and the timestamp restarts at every channel and frame -- so differencing the flattened sample grid would spike at each boundary. Rates come from the derivative of the keyframe interpolation instead.

Euler angles are left wrapped. MoveIndex turns consecutive angles into Rz(dyaw) Ry(-dpitch) Rx(droll), each factor 360-degree periodic, so wrapping is exactly equivalent; unwrapping would grow without bound and lose float32 precision over a long time record.

The glTF Y-up to RadarSimPy Z-up conversion is a similarity transform C R C^T on the orientation, with vectors and vertices rotated by C.

STEP, LINEAR and CUBICSPLINE samplers, nested hierarchies and uniform constant scale are handled. Skinning, morph targets, animated scale, non-uniform scale on an animated chain and non-triangle primitives raise a descriptive NotImplementedError -- they move individual vertices, while the ray tracer transforms each target rigidly.

mesh_kit.load_mesh gains an in-memory {"points", "cells"} branch, which is how the parts are handed over and also lets callers simulate generated geometry. Because _load_and_validate_mesh and cp_GetTargetMesh both route through it, animated targets work with sim_radar, get_target_mesh and get_scene_state at once.

pygltflib is an optional runtime dependency, discovered the way the mesh backends are, and pinned in requirements-dev.txt so CI exercises the new tests. The gltf marker skips them cleanly when it is absent.

Verified: 487 tests pass (44 new; 443 pass and 44 skip without pygltflib). An orbiting part driven through the real C++ Target::Move traces the analytic angle to 0.01 degrees. sim_radar output from a GLB-encoded constant rotation matches a hand-written rotation_rate target to 4.8e-5 relative baseband, and constant translation matches speed exactly.